### PR TITLE
Version up libraries

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.20" />
+    <option name="version" value="1.8.21" />
   </component>
 </project>

--- a/arranger-runtime/src/test/java/dev/mkeeda/arranger/runtime/SimpleEditorTest.kt
+++ b/arranger-runtime/src/test/java/dev/mkeeda/arranger/runtime/SimpleEditorTest.kt
@@ -3,6 +3,7 @@ package dev.mkeeda.arranger.runtime
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.TestMonotonicFrameClock
 import com.google.common.truth.Truth.assertThat
 import dev.mkeeda.arranger.runtime.node.HeadingLevel
@@ -13,6 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(ExperimentalTestApi::class)
 @RunWith(RobolectricTestRunner::class)
 class SimpleEditorTest {
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,18 +25,21 @@ subprojects {
                 }
             }
             compileOptions {
-                sourceCompatibility = JavaVersion.VERSION_1_8
-                targetCompatibility = JavaVersion.VERSION_1_8
+                sourceCompatibility = JavaVersion.VERSION_11
+                targetCompatibility = JavaVersion.VERSION_11
             }
             buildFeatures {
                 compose = true
             }
             composeOptions {
-                kotlinCompilerExtensionVersion = "1.3.2"
+                kotlinCompilerExtensionVersion = libs.versions.androidxComposeCompiler.get()
             }
         }
     }
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions.freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        kotlinOptions {
+            jvmTarget = "11"
+            freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "21"
 kotlin = "1.8.21"
 kotlinxCoroutine = "1.6.4"
 
-androidGradlePlugin = "8.1.0-alpha11"
+androidGradlePlugin = "8.0.1"
 
 androidxComposeCompiler = "1.4.7"
 androidxComposeUi = "1.4.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,17 +2,17 @@
 compileSdk = "33"
 minSdk = "21"
 
-kotlin = "1.7.20"
+kotlin = "1.8.21"
 kotlinxCoroutine = "1.6.4"
 
 androidGradlePlugin = "8.1.0-alpha11"
 
-androidxComposeCompiler = "1.3.2"
-androidxComposeUi = "1.3.1"
+androidxComposeCompiler = "1.4.7"
+androidxComposeUi = "1.4.3"
 
 [libraries]
 # Android Compose
-androidx-compose-runtime = "androidx.compose.runtime:runtime:1.3.1"
+androidx-compose-runtime = "androidx.compose.runtime:runtime:1.4.3"
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidxComposeUi" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidxComposeUi" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidxComposeUi" }
@@ -20,16 +20,16 @@ androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref
 androidx-compose-material3 = "androidx.compose.material3:material3:1.0.1"
 
 # Android Compose integration
-androidx-activity-compose = "androidx.activity:activity-compose:1.6.1"
+androidx-activity-compose = "androidx.activity:activity-compose:1.7.1"
 
 # AndroidX others
-androidx-core-ktx = "androidx.core:core-ktx:1.9.0"
-androidx-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
+androidx-core-ktx = "androidx.core:core-ktx:1.10.0"
+androidx-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 
 # AndroidX test frameworks
 androidx-test-core-ktx = "androidx.test:core-ktx:1.5.0"
-androidx-test-junit-ktx = "androidx.test.ext:junit-ktx:1.1.4"
-androidx-test-runner = "androidx.test:runner:1.5.1"
+androidx-test-junit-ktx = "androidx.test.ext:junit-ktx:1.1.5"
+androidx-test-runner = "androidx.test:runner:1.5.2"
 
 # Kotlin
 kotlinx-coroutines-core= { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutine" }


### PR DESCRIPTION
- Kotlin 1.8.21
- Compose 1.4.3
- Bump up to latest version of more other libraries

Downgrade AGP version from 8.1.0-alpha11 to 8.0.1.
This project uses the latest stable AGP because alpha/beta version is not compatible other Android Studio canary/beta version.