### PR TITLE
feat(text): implement Runs API and builder DSL for RichString

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/AttributeContainer.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/AttributeContainer.kt
@@ -88,3 +88,42 @@ public class AttributeContainer private constructor(
         public fun empty(): AttributeContainer = EMPTY
     }
 }
+
+/**
+ * Returns an empty [AttributeContainer].
+ */
+public fun attributeContainerOf(): AttributeContainer = AttributeContainer.empty()
+
+/**
+ * Returns a new [AttributeContainer] containing the specified key-value [p1].
+ */
+public fun <T> attributeContainerOf(
+    p1: Pair<AttributeKey<T>, T>,
+): AttributeContainer = AttributeContainer.empty() + p1
+
+/**
+ * Returns a new [AttributeContainer] containing the specified key-value pairs.
+ */
+public fun <T1, T2> attributeContainerOf(
+    p1: Pair<AttributeKey<T1>, T1>,
+    p2: Pair<AttributeKey<T2>, T2>,
+): AttributeContainer = AttributeContainer.empty() + p1 + p2
+
+/**
+ * Returns a new [AttributeContainer] containing the specified key-value pairs.
+ */
+public fun <T1, T2, T3> attributeContainerOf(
+    p1: Pair<AttributeKey<T1>, T1>,
+    p2: Pair<AttributeKey<T2>, T2>,
+    p3: Pair<AttributeKey<T3>, T3>,
+): AttributeContainer = AttributeContainer.empty() + p1 + p2 + p3
+
+/**
+ * Returns a new [AttributeContainer] containing the specified key-value pairs.
+ */
+public fun <T1, T2, T3, T4> attributeContainerOf(
+    p1: Pair<AttributeKey<T1>, T1>,
+    p2: Pair<AttributeKey<T2>, T2>,
+    p3: Pair<AttributeKey<T3>, T3>,
+    p4: Pair<AttributeKey<T4>, T4>,
+): AttributeContainer = AttributeContainer.empty() + p1 + p2 + p3 + p4

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/AttributeContainer.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/AttributeContainer.kt
@@ -29,13 +29,31 @@ public class AttributeContainer private constructor(
     }
 
     /**
+     * Returns true if this container contains no attributes.
+     */
+    public fun isEmpty(): Boolean = attributes.isEmpty()
+
+    /**
      * Returns a new [AttributeContainer] with the specified [key] mapped to the [value].
      */
-    public fun <T> with(
+    public fun <T> plus(
         key: AttributeKey<T>,
         value: T,
     ): AttributeContainer {
         return AttributeContainer(attributes = attributes + (key to value))
+    }
+
+    /**
+     * Returns a new [AttributeContainer] with the specified key-value [pair].
+     */
+    public operator fun <T> plus(pair: Pair<AttributeKey<T>, T>): AttributeContainer = plus(pair.first, pair.second)
+
+    /**
+     * Returns a new [AttributeContainer] with the specified [key] removed.
+     */
+    public operator fun <T> minus(key: AttributeKey<T>): AttributeContainer {
+        if (!attributes.containsKey(key)) return this
+        return AttributeContainer(attributes = attributes - key)
     }
 
     /**

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/AttributeContainer.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/AttributeContainer.kt
@@ -49,14 +49,6 @@ public class AttributeContainer private constructor(
     public operator fun <T> plus(pair: Pair<AttributeKey<T>, T>): AttributeContainer = plus(pair.first, pair.second)
 
     /**
-     * Returns a new [AttributeContainer] with the specified [key] removed.
-     */
-    public operator fun <T> minus(key: AttributeKey<T>): AttributeContainer {
-        if (!attributes.containsKey(key)) return this
-        return AttributeContainer(attributes = attributes - key)
-    }
-
-    /**
      * Returns a new [AttributeContainer] containing all attributes from this and the [other].
      * If keys collide, values from [other] take precedence (overwrite).
      */
@@ -64,6 +56,14 @@ public class AttributeContainer private constructor(
         if (other.attributes.isEmpty()) return this
         if (this.attributes.isEmpty()) return other
         return AttributeContainer(attributes = attributes + other.attributes)
+    }
+
+    /**
+     * Returns a new [AttributeContainer] with the specified [key] removed.
+     */
+    public operator fun <T> minus(key: AttributeKey<T>): AttributeContainer {
+        if (!attributes.containsKey(key)) return this
+        return AttributeContainer(attributes = attributes - key)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichRun.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichRun.kt
@@ -1,0 +1,15 @@
+package dev.mkeeda.arranger.core.text
+
+/**
+ * Represents a contiguous block of text where a specific attribute is continuously applied.
+ *
+ * @param T The type of the attribute value.
+ * @property text The substring corresponding to this run.
+ * @property range The character range (inclusive) within the original text.
+ * @property value The value of the specific attribute queried.
+ */
+public data class RichRun<T>(
+    val text: String,
+    val range: IntRange,
+    val value: T,
+)

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichString.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichString.kt
@@ -13,30 +13,58 @@ public class RichString(
     private val spans: List<RichSpan> = emptyList(),
 ) {
     /**
-     * Returns a new [RichString] with the given attribute applied to the entire text.
+     * Creates a new [RichString] having the given [initialAttributes] applied to the entire text.
      */
-    public fun <T> with(key: AttributeKey<T>, value: T): RichString {
-        return with(key, value, range = text.indices)
-    }
-
-    /**
-     * Returns a new [RichString] with the given attribute applied to the specified [range].
-     */
-    public fun <T> with(key: AttributeKey<T>, value: T, range: IntRange): RichString {
-        require(!range.isEmpty()) { "Range must not be empty: $range" }
-        require(range.first >= 0) { "Range start must not be negative: ${range.first}" }
-        require(range.last < text.length) { "Range end must be within text bounds: ${range.last} >= ${text.length}" }
-
-        val newSpan =
-            RichSpan(
-                range = range,
-                attributes = AttributeContainer.empty().with(key, value),
-            )
-        return RichString(text = text, spans = mergeSpans(spans, newSpan))
-    }
+    public constructor(text: String, initialAttributes: AttributeContainer) : this(
+        text = text,
+        spans =
+            if (text.isEmpty() || initialAttributes.isEmpty()) {
+                emptyList()
+            } else {
+                listOf(RichSpan(text.indices, initialAttributes))
+            },
+    )
 
     /**
      * Returns a snapshot of all [RichSpan]s currently held by this [RichString].
      */
     public fun getSpans(): List<RichSpan> = spans
+
+    /**
+     * Retrieves all contiguous runs of the requested attribute [key], merging internally split spans.
+     * Adjacent internal spans that possess the EXACT SAME attribute value for [key] will be combined
+     * into a single [RichRun], ignoring differences in other attributes.
+     */
+    public fun <T> runs(key: AttributeKey<T>): List<RichRun<T>> {
+        // Isolate the requested attribute, allowing `transformSpans` to automatically
+        // drop spans where it is absent and coalesce contiguous spans where the value is identical.
+        val isolatedSpans =
+            spans.transformSpans(text.indices) { attributes ->
+                val value = attributes.getOrNull(key)
+                if (value != null) {
+                    AttributeContainer.empty().plus(key, value)
+                } else {
+                    AttributeContainer.empty()
+                }
+            }
+
+        return isolatedSpans.map { span ->
+            @Suppress("UNCHECKED_CAST")
+            RichRun(
+                text = text.substring(span.range),
+                range = span.range,
+                value = span.attributes.getOrNull(key) as T,
+            )
+        }
+    }
+
+    /**
+     * Executes the given [block] on a [RichStringBuilder] scoped to this [RichString],
+     * and returns a completely new [RichString] carrying the modifications.
+     */
+    public fun edit(block: RichStringBuilder.() -> Unit): RichString {
+        val builder = RichStringBuilder(currentSpans = spans, textLength = text.length)
+        builder.block()
+        return builder.build(text = text)
+    }
 }

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichString.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichString.kt
@@ -21,7 +21,7 @@ public class RichString(
             if (text.isEmpty() || initialAttributes.isEmpty()) {
                 emptyList()
             } else {
-                listOf(RichSpan(text.indices, initialAttributes))
+                listOf(RichSpan(range = text.indices, attributes = initialAttributes))
             },
     )
 
@@ -39,7 +39,7 @@ public class RichString(
         // Isolate the requested attribute, allowing `transformSpans` to automatically
         // drop spans where it is absent and coalesce contiguous spans where the value is identical.
         val isolatedSpans =
-            spans.transformSpans(text.indices) { attributes ->
+            spans.transformSpans(targetRange = text.indices) { attributes ->
                 val value = attributes.getOrNull(key)
                 if (value != null) {
                     AttributeContainer.empty().plus(key, value)

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichStringBuilder.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichStringBuilder.kt
@@ -20,7 +20,7 @@ public class RichStringBuilder internal constructor(
     ) {
         checkRange(range)
         currentSpans =
-            currentSpans.transformSpans(range) { attributes ->
+            currentSpans.transformSpans(targetRange = range) { attributes ->
                 attributes.plus(key, value)
             }
     }
@@ -34,7 +34,7 @@ public class RichStringBuilder internal constructor(
     ) {
         checkRange(range)
         currentSpans =
-            currentSpans.transformSpans(range) { attributes ->
+            currentSpans.transformSpans(targetRange = range) { attributes ->
                 attributes - key
             }
     }

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichStringBuilder.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/RichStringBuilder.kt
@@ -1,0 +1,51 @@
+package dev.mkeeda.arranger.core.text
+
+/**
+ * A builder class used to safely mutate the attributes of a [RichString] within an `edit` block.
+ * All mutations are accumulated internally and used to produce a completely new, immutable [RichString] instance
+ * when the block completes.
+ */
+public class RichStringBuilder internal constructor(
+    private var currentSpans: List<RichSpan>,
+    private val textLength: Int,
+) {
+    /**
+     * Applies the specified attribute [key] and [value] to the given [range].
+     * Any existing attributes of the same key within this range are completely overwritten.
+     */
+    public fun <T> setAttribute(
+        key: AttributeKey<T>,
+        value: T,
+        range: IntRange = 0 until textLength,
+    ) {
+        checkRange(range)
+        currentSpans =
+            currentSpans.transformSpans(range) { attributes ->
+                attributes.plus(key, value)
+            }
+    }
+
+    /**
+     * Removes any attributes associated with the specified [key] within the given [range].
+     */
+    public fun <T> removeAttribute(
+        key: AttributeKey<T>,
+        range: IntRange = 0 until textLength,
+    ) {
+        checkRange(range)
+        currentSpans =
+            currentSpans.transformSpans(range) { attributes ->
+                attributes - key
+            }
+    }
+
+    private fun checkRange(range: IntRange) {
+        require(!range.isEmpty()) { "Range must not be empty: $range" }
+        require(range.first >= 0) { "Range start must not be negative: ${range.first}" }
+        require(range.last < textLength) { "Range end must be within text bounds: ${range.last} >= $textLength" }
+    }
+
+    internal fun build(text: String): RichString {
+        return RichString(text = text, spans = currentSpans)
+    }
+}

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/SpanMerger.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/SpanMerger.kt
@@ -1,39 +1,40 @@
 package dev.mkeeda.arranger.core.text
 
 /**
- * Merges a [newSpan] into a list of [existingSpans], resolving any overlaps.
+ * Applies a given [transform] to the attributes of this list of spans within the [targetRange].
  *
- * This function handles partial overlaps, complete containments, and full
- * overwriting by guaranteeing that the resulting list of spans is
- * strictly non-overlapping and sorted.
+ * This function handles partial overlaps and full coverage by splitting spans as needed
+ * to apply the transformation exclusively within the [targetRange].
  *
  * It utilizes a sweep-line style interval chunking algorithm:
  * 1. Extract interval boundaries (`start` and `end + 1`) from all existing
- *    spans and the [newSpan].
+ *    spans and the [targetRange].
  * 2. Uniquely sort these boundary points.
  * 3. Iterate through adjacent pairs of boundary points to create perfectly
  *    tessellated, non-overlapping sub-ranges (chunks).
  * 4. For each chunk, determine its coverage:
- *    - Inside both new and existing spans: merge attributes (new overwrites existing).
- *    - Inside only one: map directly to its attributes.
- *    - Inside neither: skip chunk (pure text without attributes).
- * 5. After attribute assessment, consecutive chunks with identically matched
- *    [AttributeContainer]s are consolidated back together for optimization.
- *
- * @param existingSpans The current sorted list of non-overlapping spans.
- * @param newSpan The incoming span to be applied over the existing ones.
- * @return A new, optimized list of strictly non-overlapping spans.
+ *    - Inside both target range and existing spans: apply transform to the existing attributes.
+ *    - Inside target range only: apply transform to an Empty container.
+ *    - Inside existing span only: keep existing attributes untouched.
+ * 5. If the resulting attribute container is completely empty for a chunk, it is omitted.
+ * 6. Contiguous spans with identical attributes are coalesced optimizations.
  */
-internal fun mergeSpans(existingSpans: List<RichSpan>, newSpan: RichSpan): List<RichSpan> {
-    if (existingSpans.isEmpty()) return listOf(newSpan)
+internal fun List<RichSpan>.transformSpans(
+    targetRange: IntRange,
+    transform: (AttributeContainer) -> AttributeContainer,
+): List<RichSpan> {
+    if (this.isEmpty() && targetRange.isEmpty()) return emptyList()
+    val nonEmptytargetRange = if (targetRange.isEmpty()) null else targetRange
 
     // 1. Extract boundaries and sort uniquely
     val boundaries =
         buildList {
-            add(newSpan.range.first)
-            add(newSpan.range.last + 1)
+            if (nonEmptytargetRange != null) {
+                add(nonEmptytargetRange.first)
+                add(nonEmptytargetRange.last + 1)
+            }
 
-            for (span in existingSpans) {
+            for (span in this@transformSpans) {
                 add(span.range.first)
                 add(span.range.last + 1)
             }
@@ -51,26 +52,30 @@ internal fun mergeSpans(existingSpans: List<RichSpan>, newSpan: RichSpan): List<
 
         // Advance existing span pointer to catch up with the current chunk
         while (
-            currentSpanIndex < existingSpans.size &&
-            existingSpans[currentSpanIndex].range.last < chunkStart
+            currentSpanIndex < this.size &&
+            this[currentSpanIndex].range.last < chunkStart
         ) {
             currentSpanIndex++
         }
 
-        val isInsideNewSpan = chunkStart >= newSpan.range.first && chunkEnd <= newSpan.range.last
+        val isInsideTarget = nonEmptytargetRange != null && chunkStart >= nonEmptytargetRange.first && chunkEnd <= nonEmptytargetRange.last
 
         val isInsideExistingSpan =
-            currentSpanIndex < existingSpans.size &&
-                chunkStart >= existingSpans[currentSpanIndex].range.first &&
-                chunkEnd <= existingSpans[currentSpanIndex].range.last
+            currentSpanIndex < this.size &&
+                chunkStart >= this[currentSpanIndex].range.first &&
+                chunkEnd <= this[currentSpanIndex].range.last
 
         val chunkAttributes: AttributeContainer =
             when {
-                isInsideNewSpan && isInsideExistingSpan -> existingSpans[currentSpanIndex].attributes + newSpan.attributes
-                isInsideNewSpan -> newSpan.attributes
-                isInsideExistingSpan -> existingSpans[currentSpanIndex].attributes
+                isInsideTarget && isInsideExistingSpan -> transform(this[currentSpanIndex].attributes)
+                isInsideTarget -> transform(AttributeContainer.empty())
+                isInsideExistingSpan -> this[currentSpanIndex].attributes
                 else -> continue // Blank gap (no attributes), skip this chunk
             }
+
+        if (chunkAttributes.isEmpty()) {
+            continue
+        }
 
         val nextSpan = RichSpan(range = chunkStart..chunkEnd, attributes = chunkAttributes)
 
@@ -95,4 +100,14 @@ internal fun mergeSpans(existingSpans: List<RichSpan>, newSpan: RichSpan): List<
     }
 
     return resultSpans
+}
+
+/**
+ * Merges a [newSpan] into this list of spans.
+ * Convenience extension that wraps [transformSpans].
+ */
+internal fun List<RichSpan>.mergeSpan(newSpan: RichSpan): List<RichSpan> {
+    return transformSpans(newSpan.range) { existingAttributes ->
+        existingAttributes + newSpan.attributes
+    }
 }

--- a/core/src/main/kotlin/dev/mkeeda/arranger/core/text/SpanMerger.kt
+++ b/core/src/main/kotlin/dev/mkeeda/arranger/core/text/SpanMerger.kt
@@ -24,14 +24,14 @@ internal fun List<RichSpan>.transformSpans(
     transform: (AttributeContainer) -> AttributeContainer,
 ): List<RichSpan> {
     if (this.isEmpty() && targetRange.isEmpty()) return emptyList()
-    val nonEmptytargetRange = if (targetRange.isEmpty()) null else targetRange
+    val nonEmptyTargetRange = if (targetRange.isEmpty()) null else targetRange
 
     // 1. Extract boundaries and sort uniquely
     val boundaries =
         buildList {
-            if (nonEmptytargetRange != null) {
-                add(nonEmptytargetRange.first)
-                add(nonEmptytargetRange.last + 1)
+            if (nonEmptyTargetRange != null) {
+                add(nonEmptyTargetRange.first)
+                add(nonEmptyTargetRange.last + 1)
             }
 
             for (span in this@transformSpans) {
@@ -58,7 +58,7 @@ internal fun List<RichSpan>.transformSpans(
             currentSpanIndex++
         }
 
-        val isInsideTarget = nonEmptytargetRange != null && chunkStart >= nonEmptytargetRange.first && chunkEnd <= nonEmptytargetRange.last
+        val isInsideTarget = nonEmptyTargetRange != null && chunkStart >= nonEmptyTargetRange.first && chunkEnd <= nonEmptyTargetRange.last
 
         val isInsideExistingSpan =
             currentSpanIndex < this.size &&
@@ -107,7 +107,7 @@ internal fun List<RichSpan>.transformSpans(
  * Convenience extension that wraps [transformSpans].
  */
 internal fun List<RichSpan>.mergeSpan(newSpan: RichSpan): List<RichSpan> {
-    return transformSpans(newSpan.range) { existingAttributes ->
+    return transformSpans(targetRange = newSpan.range) { existingAttributes ->
         existingAttributes + newSpan.attributes
     }
 }

--- a/core/src/test/kotlin/dev/mkeeda/arranger/core/text/AttributeContainerTest.kt
+++ b/core/src/test/kotlin/dev/mkeeda/arranger/core/text/AttributeContainerTest.kt
@@ -2,6 +2,7 @@ package dev.mkeeda.arranger.core.text
 
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.junit.Test
 
 class AttributeContainerTest {
@@ -9,8 +10,8 @@ class AttributeContainerTest {
     fun `stores and retrieves attributes in a type-safe manner`() {
         val container =
             AttributeContainer.empty()
-                .with(MentionAttributeKey, "@mkeeda")
-                .with(ColorAttributeKey, TextColor.Red)
+                .plus(MentionAttributeKey, "@mkeeda")
+                .plus(ColorAttributeKey, TextColor.Red)
 
         val mention: String? = container.getOrNull(MentionAttributeKey)
         val color: TextColor? = container.getOrNull(ColorAttributeKey)
@@ -23,8 +24,8 @@ class AttributeContainerTest {
     fun `provides intuitive and type-safe access using extension functions and properties`() {
         val container =
             AttributeContainer.empty()
-                .withMention("@mkeeda")
-                .withTextColor(TextColor.Blue)
+                .plusMention("@mkeeda")
+                .plusTextColor(TextColor.Blue)
 
         container.mention shouldBe "@mkeeda"
         container.textColor shouldBe TextColor.Blue
@@ -47,9 +48,63 @@ class AttributeContainerTest {
     fun `retains the newly set value when overwriting an attribute with the same name`() {
         val container =
             AttributeContainer.empty()
-                .withTextColor(TextColor.Red)
-                .withTextColor(TextColor.Blue)
+                .plusTextColor(TextColor.Red)
+                .plusTextColor(TextColor.Blue)
 
         container.textColor shouldBe TextColor.Blue
+    }
+
+    @Test
+    fun `plus returns new container maintaining immutability`() {
+        val c1 = AttributeContainer.empty()
+        val c2 = c1.plus(MentionAttributeKey, "@all")
+        val c3 = c2.plus(ColorAttributeKey, TextColor.Red)
+
+        c1.getOrNull(MentionAttributeKey).shouldBeNull()
+
+        c2.getOrNull(MentionAttributeKey) shouldBe "@all"
+        c2.getOrNull(ColorAttributeKey).shouldBeNull()
+
+        c3.getOrNull(MentionAttributeKey) shouldBe "@all"
+        c3.getOrNull(ColorAttributeKey) shouldBe TextColor.Red
+    }
+
+    @Test
+    fun `plus operator merges two containers properly`() {
+        val c1 = AttributeContainer.empty().plusMention("@mkeeda")
+        val c2 = AttributeContainer.empty().plusTextColor(TextColor.Blue)
+
+        val merged = c1 + c2
+
+        merged.getOrDefault(MentionAttributeKey) shouldBe "@mkeeda"
+        merged.getOrDefault(ColorAttributeKey) shouldBe TextColor.Blue
+    }
+
+    @Test
+    fun `isEmpty correctly reports empty state`() {
+        val empty = AttributeContainer.empty()
+        empty.isEmpty() shouldBe true
+
+        val notEmpty = empty.plusMention("@user")
+        notEmpty.isEmpty() shouldBe false
+    }
+
+    @Test
+    fun `minus correctly removes attribute and maintains immutability`() {
+        val c1 = AttributeContainer.empty().plusMention("@user").plusTextColor(TextColor.Red)
+
+        val c2 = c1 - ColorAttributeKey
+
+        c1.getOrNull(ColorAttributeKey) shouldBe TextColor.Red
+        c2.getOrNull(ColorAttributeKey).shouldBeNull()
+        c2.getOrNull(MentionAttributeKey) shouldBe "@user"
+    }
+
+    @Test
+    fun `minus on missing key returns same instance`() {
+        val c1 = AttributeContainer.empty().plusMention("@user")
+        val c2 = c1 - ColorAttributeKey
+
+        c2 shouldBeSameInstanceAs c1
     }
 }

--- a/core/src/test/kotlin/dev/mkeeda/arranger/core/text/AttributeContainerTest.kt
+++ b/core/src/test/kotlin/dev/mkeeda/arranger/core/text/AttributeContainerTest.kt
@@ -9,9 +9,10 @@ class AttributeContainerTest {
     @Test
     fun `stores and retrieves attributes in a type-safe manner`() {
         val container =
-            AttributeContainer.empty()
-                .plus(MentionAttributeKey, "@mkeeda")
-                .plus(ColorAttributeKey, TextColor.Red)
+            attributeContainerOf(
+                MentionAttributeKey to "@mkeeda",
+                ColorAttributeKey to TextColor.Red,
+            )
 
         val mention: String? = container.getOrNull(MentionAttributeKey)
         val color: TextColor? = container.getOrNull(ColorAttributeKey)
@@ -23,9 +24,10 @@ class AttributeContainerTest {
     @Test
     fun `provides intuitive and type-safe access using extension functions and properties`() {
         val container =
-            AttributeContainer.empty()
-                .plusMention("@mkeeda")
-                .plusTextColor(TextColor.Blue)
+            attributeContainerOf(
+                MentionAttributeKey to "@mkeeda",
+                ColorAttributeKey to TextColor.Blue,
+            )
 
         container.mention shouldBe "@mkeeda"
         container.textColor shouldBe TextColor.Blue
@@ -33,7 +35,7 @@ class AttributeContainerTest {
 
     @Test
     fun `returns defaultValue or null when retrieving an unset attribute`() {
-        val emptyContainer = AttributeContainer.empty()
+        val emptyContainer = attributeContainerOf()
 
         // getOrDefault
         emptyContainer.getOrDefault(MentionAttributeKey) shouldBe ""
@@ -47,16 +49,17 @@ class AttributeContainerTest {
     @Test
     fun `retains the newly set value when overwriting an attribute with the same name`() {
         val container =
-            AttributeContainer.empty()
-                .plusTextColor(TextColor.Red)
-                .plusTextColor(TextColor.Blue)
+            attributeContainerOf(
+                ColorAttributeKey to TextColor.Red,
+                ColorAttributeKey to TextColor.Blue,
+            )
 
         container.textColor shouldBe TextColor.Blue
     }
 
     @Test
     fun `plus returns new container maintaining immutability`() {
-        val c1 = AttributeContainer.empty()
+        val c1 = attributeContainerOf()
         val c2 = c1.plus(MentionAttributeKey, "@all")
         val c3 = c2.plus(ColorAttributeKey, TextColor.Red)
 
@@ -71,8 +74,8 @@ class AttributeContainerTest {
 
     @Test
     fun `plus operator merges two containers properly`() {
-        val c1 = AttributeContainer.empty().plusMention("@mkeeda")
-        val c2 = AttributeContainer.empty().plusTextColor(TextColor.Blue)
+        val c1 = attributeContainerOf(MentionAttributeKey to "@mkeeda")
+        val c2 = attributeContainerOf(ColorAttributeKey to TextColor.Blue)
 
         val merged = c1 + c2
 
@@ -82,16 +85,16 @@ class AttributeContainerTest {
 
     @Test
     fun `isEmpty correctly reports empty state`() {
-        val empty = AttributeContainer.empty()
+        val empty = attributeContainerOf()
         empty.isEmpty() shouldBe true
 
-        val notEmpty = empty.plusMention("@user")
+        val notEmpty = empty + (MentionAttributeKey to "@user")
         notEmpty.isEmpty() shouldBe false
     }
 
     @Test
     fun `minus correctly removes attribute and maintains immutability`() {
-        val c1 = AttributeContainer.empty().plusMention("@user").plusTextColor(TextColor.Red)
+        val c1 = attributeContainerOf(MentionAttributeKey to "@user", ColorAttributeKey to TextColor.Red)
 
         val c2 = c1 - ColorAttributeKey
 
@@ -102,9 +105,26 @@ class AttributeContainerTest {
 
     @Test
     fun `minus on missing key returns same instance`() {
-        val c1 = AttributeContainer.empty().plusMention("@user")
+        val c1 = attributeContainerOf(MentionAttributeKey to "@user")
         val c2 = c1 - ColorAttributeKey
 
         c2 shouldBeSameInstanceAs c1
+    }
+
+    @Test
+    fun `attributeContainerOf factory functions create correct containers type-safely`() {
+        val empty = attributeContainerOf()
+        empty.isEmpty() shouldBe true
+
+        val onePair = attributeContainerOf(MentionAttributeKey to "@user")
+        onePair.getOrNull(MentionAttributeKey) shouldBe "@user"
+
+        val twoPairs =
+            attributeContainerOf(
+                MentionAttributeKey to "@mkeeda",
+                ColorAttributeKey to TextColor.Red,
+            )
+        twoPairs.getOrNull(MentionAttributeKey) shouldBe "@mkeeda"
+        twoPairs.getOrNull(ColorAttributeKey) shouldBe TextColor.Red
     }
 }

--- a/core/src/test/kotlin/dev/mkeeda/arranger/core/text/RichStringTest.kt
+++ b/core/src/test/kotlin/dev/mkeeda/arranger/core/text/RichStringTest.kt
@@ -52,8 +52,10 @@ class RichStringTest {
     fun `applies multiple different attributes to different ranges`() {
         val richString =
             RichString(text = "Hello, World!")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
-                .edit { setAttribute(MentionAttributeKey, "@user", range = 7..11) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4)
+                    setAttribute(MentionAttributeKey, "@user", range = 7..11)
+                }
 
         richString.text shouldBe "Hello, World!"
         val spans = richString.getSpans()
@@ -125,8 +127,10 @@ class RichStringTest {
         // [11..15] Mention=@user
         val richString =
             RichString("1234567890123456")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10) }
-                .edit { setAttribute(MentionAttributeKey, "@user", range = 5..15) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10)
+                    setAttribute(MentionAttributeKey, "@user", range = 5..15)
+                }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 3
@@ -153,8 +157,10 @@ class RichStringTest {
         // [8..10] Color=Red
         val richString =
             RichString("12345678901")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10) }
-                .edit { setAttribute(MentionAttributeKey, "@user", range = 3..7) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10)
+                    setAttribute(MentionAttributeKey, "@user", range = 3..7)
+                }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 3
@@ -176,8 +182,10 @@ class RichStringTest {
     fun `overwrites completely when same attribute key is applied over existing span`() {
         val richString =
             RichString("12345678901")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10) }
-                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 0..10) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10)
+                    setAttribute(ColorAttributeKey, TextColor.Blue, range = 0..10)
+                }
 
         // It should perfectly replace the attribute and optimize back to 1 span
         val spans = richString.getSpans()
@@ -199,9 +207,11 @@ class RichStringTest {
         // [11..12] Color=Red
         val richString =
             RichString("1234567890123")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 8..12) }
-                .edit { setAttribute(MentionAttributeKey, "@user", range = 2..10) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4)
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 8..12)
+                    setAttribute(MentionAttributeKey, "@user", range = 2..10)
+                }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 5
@@ -226,8 +236,10 @@ class RichStringTest {
     fun `merges adjacent spans when attributes are perfectly identical`() {
         val richString =
             RichString("12345678901")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 5..10) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4)
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 5..10)
+                }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 1
@@ -243,11 +255,13 @@ class RichStringTest {
         // [16..19] Mention=@other_user
         val richString =
             RichString("12345678901234567890")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
-                .edit { setAttribute(MentionAttributeKey, "@user", range = 5..9) }
-                .edit { setAttribute(MentionAttributeKey, "@user", range = 10..15) }
-                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 10..15) }
-                .edit { setAttribute(MentionAttributeKey, "@other_user", range = 16..19) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4)
+                    setAttribute(MentionAttributeKey, "@user", range = 5..9)
+                    setAttribute(MentionAttributeKey, "@user", range = 10..15)
+                    setAttribute(ColorAttributeKey, TextColor.Blue, range = 10..15)
+                    setAttribute(MentionAttributeKey, "@other_user", range = 16..19)
+                }
 
         // There should be 4 internal spans: [0..4], [5..9], [10..15], [16..19]
         richString.getSpans() shouldHaveSize 4
@@ -271,9 +285,11 @@ class RichStringTest {
     fun `runs handles gaps correctly and only returns regions with the attribute`() {
         val richString =
             RichString("01234567890123456789") // length 20
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 2..4) }
-                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 8..10) }
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 15..19) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 2..4)
+                    setAttribute(ColorAttributeKey, TextColor.Blue, range = 8..10)
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 15..19)
+                }
 
         val colorRuns = richString.runs(ColorAttributeKey)
 
@@ -293,8 +309,10 @@ class RichStringTest {
     fun `edit block allows building new RichString with multiple operations safely`() {
         val original =
             RichString("12345678901234567890")
-                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..9) }
-                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 10..19) }
+                .edit {
+                    setAttribute(ColorAttributeKey, TextColor.Red, range = 0..9)
+                    setAttribute(ColorAttributeKey, TextColor.Blue, range = 10..19)
+                }
 
         val edited =
             original.edit {
@@ -331,7 +349,7 @@ class RichStringTest {
 
     @Test
     fun `edit block handles empty spans and no-op correctly`() {
-        val original = RichString("hello").edit { setAttribute(ColorAttributeKey, TextColor.Red) }
+        val original = RichString("hello", attributeContainerOf(ColorAttributeKey to TextColor.Red))
         val edited =
             original.edit {
                 // Do nothing

--- a/core/src/test/kotlin/dev/mkeeda/arranger/core/text/RichStringTest.kt
+++ b/core/src/test/kotlin/dev/mkeeda/arranger/core/text/RichStringTest.kt
@@ -18,7 +18,7 @@ class RichStringTest {
     @Test
     fun `applies an attribute to the entire text and returns a new immutable instance`() {
         val original = RichString(text = "Hello")
-        val styled = original.with(ColorAttributeKey, TextColor.Red)
+        val styled = original.edit { setAttribute(ColorAttributeKey, TextColor.Red) }
 
         // A new instance is returned (immutability)
         styled shouldNotBe original
@@ -39,7 +39,7 @@ class RichStringTest {
     fun `applies an attribute to a specific range`() {
         val richString =
             RichString(text = "Hello, World!")
-                .with(ColorAttributeKey, TextColor.Blue, range = 0..4)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 0..4) }
 
         richString.text shouldBe "Hello, World!"
         val spans = richString.getSpans()
@@ -52,8 +52,8 @@ class RichStringTest {
     fun `applies multiple different attributes to different ranges`() {
         val richString =
             RichString(text = "Hello, World!")
-                .with(ColorAttributeKey, TextColor.Red, range = 0..4)
-                .with(MentionAttributeKey, "@user", range = 7..11)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
+                .edit { setAttribute(MentionAttributeKey, "@user", range = 7..11) }
 
         richString.text shouldBe "Hello, World!"
         val spans = richString.getSpans()
@@ -79,7 +79,7 @@ class RichStringTest {
         val richString = RichString(text = "Hello, World!")
         val exception =
             shouldThrow<IllegalArgumentException> {
-                richString.with(ColorAttributeKey, TextColor.Red, range = -1..3)
+                richString.edit { setAttribute(ColorAttributeKey, TextColor.Red, range = -1..3) }
             }
         exception.message shouldBe "Range start must not be negative: -1"
     }
@@ -89,7 +89,7 @@ class RichStringTest {
         val richString = RichString(text = "Hello")
         val exception =
             shouldThrow<IllegalArgumentException> {
-                richString.with(ColorAttributeKey, TextColor.Red, range = 0..5)
+                richString.edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..5) }
             }
         exception.message shouldBe "Range end must be within text bounds: 5 >= 5"
     }
@@ -99,7 +99,7 @@ class RichStringTest {
         val richString = RichString(text = "Hello, World!")
         val exception =
             shouldThrow<IllegalArgumentException> {
-                richString.with(ColorAttributeKey, TextColor.Red, range = 5..3)
+                richString.edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 5..3) }
             }
         exception.message shouldBe "Range must not be empty: 5..3"
     }
@@ -108,7 +108,7 @@ class RichStringTest {
     fun `successfully applies an attribute to a 1-character range`() {
         val richString =
             RichString(text = "Hello")
-                .with(ColorAttributeKey, TextColor.Blue, range = 3..3)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 3..3) }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 1
@@ -125,8 +125,8 @@ class RichStringTest {
         // [11..15] Mention=@user
         val richString =
             RichString("1234567890123456")
-                .with(ColorAttributeKey, TextColor.Red, range = 0..10)
-                .with(MentionAttributeKey, "@user", range = 5..15)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10) }
+                .edit { setAttribute(MentionAttributeKey, "@user", range = 5..15) }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 3
@@ -153,8 +153,8 @@ class RichStringTest {
         // [8..10] Color=Red
         val richString =
             RichString("12345678901")
-                .with(ColorAttributeKey, TextColor.Red, range = 0..10)
-                .with(MentionAttributeKey, "@user", range = 3..7)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10) }
+                .edit { setAttribute(MentionAttributeKey, "@user", range = 3..7) }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 3
@@ -176,8 +176,8 @@ class RichStringTest {
     fun `overwrites completely when same attribute key is applied over existing span`() {
         val richString =
             RichString("12345678901")
-                .with(ColorAttributeKey, TextColor.Red, range = 0..10)
-                .with(ColorAttributeKey, TextColor.Blue, range = 0..10)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..10) }
+                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 0..10) }
 
         // It should perfectly replace the attribute and optimize back to 1 span
         val spans = richString.getSpans()
@@ -199,9 +199,9 @@ class RichStringTest {
         // [11..12] Color=Red
         val richString =
             RichString("1234567890123")
-                .with(ColorAttributeKey, TextColor.Red, range = 0..4)
-                .with(ColorAttributeKey, TextColor.Red, range = 8..12)
-                .with(MentionAttributeKey, "@user", range = 2..10)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 8..12) }
+                .edit { setAttribute(MentionAttributeKey, "@user", range = 2..10) }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 5
@@ -226,12 +226,118 @@ class RichStringTest {
     fun `merges adjacent spans when attributes are perfectly identical`() {
         val richString =
             RichString("12345678901")
-                .with(ColorAttributeKey, TextColor.Red, range = 0..4)
-                .with(ColorAttributeKey, TextColor.Red, range = 5..10)
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 5..10) }
 
         val spans = richString.getSpans()
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..10
         spans[0].attributes.getOrNull(ColorAttributeKey) shouldBe TextColor.Red
+    }
+
+    @Test
+    fun `runs returns continuous chunks of the same queried attribute value, ignoring other attributes`() {
+        // [0..4] Color=Red
+        // [5..9] Mention=@user
+        // [10..15] Mention=@user, Color=Blue
+        // [16..19] Mention=@other_user
+        val richString =
+            RichString("12345678901234567890")
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..4) }
+                .edit { setAttribute(MentionAttributeKey, "@user", range = 5..9) }
+                .edit { setAttribute(MentionAttributeKey, "@user", range = 10..15) }
+                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 10..15) }
+                .edit { setAttribute(MentionAttributeKey, "@other_user", range = 16..19) }
+
+        // There should be 4 internal spans: [0..4], [5..9], [10..15], [16..19]
+        richString.getSpans() shouldHaveSize 4
+
+        val mentionRuns = richString.runs(MentionAttributeKey)
+
+        // However, the runs API should merge [5..9] and [10..15]
+        // because both have Mention=@user, ignoring the color change.
+        mentionRuns shouldHaveSize 2
+
+        mentionRuns[0].range shouldBe 5..15
+        mentionRuns[0].value shouldBe "@user"
+        mentionRuns[0].text shouldBe "67890123456"
+
+        mentionRuns[1].range shouldBe 16..19
+        mentionRuns[1].value shouldBe "@other_user"
+        mentionRuns[1].text shouldBe "7890"
+    }
+
+    @Test
+    fun `runs handles gaps correctly and only returns regions with the attribute`() {
+        val richString =
+            RichString("01234567890123456789") // length 20
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 2..4) }
+                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 8..10) }
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 15..19) }
+
+        val colorRuns = richString.runs(ColorAttributeKey)
+
+        colorRuns shouldHaveSize 3
+
+        colorRuns[0].range shouldBe 2..4
+        colorRuns[0].value shouldBe TextColor.Red
+
+        colorRuns[1].range shouldBe 8..10
+        colorRuns[1].value shouldBe TextColor.Blue
+
+        colorRuns[2].range shouldBe 15..19
+        colorRuns[2].value shouldBe TextColor.Red
+    }
+
+    @Test
+    fun `edit block allows building new RichString with multiple operations safely`() {
+        val original =
+            RichString("12345678901234567890")
+                .edit { setAttribute(ColorAttributeKey, TextColor.Red, range = 0..9) }
+                .edit { setAttribute(ColorAttributeKey, TextColor.Blue, range = 10..19) }
+
+        val edited =
+            original.edit {
+                // Apply mention to the middle
+                setAttribute(MentionAttributeKey, "@all", range = 5..14)
+                // Remove the color over a sub-range
+                removeAttribute(ColorAttributeKey, range = 8..11)
+                // Add a completely new attribute spanning across everything
+                setAttribute(ColorAttributeKey, TextColor.Unspecified, range = 2..17)
+            }
+
+        // Original remains completely unchanged
+        original.getSpans() shouldHaveSize 2
+        original.getSpans()[0].attributes.getOrNull(ColorAttributeKey) shouldBe TextColor.Red
+
+        // Edited contains the new attributes
+        edited.runs(MentionAttributeKey)[0].range shouldBe 5..14
+
+        // Assert color spans in the edited version
+        val colorRuns = edited.runs(ColorAttributeKey)
+
+        // Color runs:
+        // [0..1] Red
+        // [2..17] Unspecified (from the last set operation override)
+        // [18..19] Blue
+        colorRuns shouldHaveSize 3
+        colorRuns[0].range shouldBe 0..1
+        colorRuns[0].value shouldBe TextColor.Red
+        colorRuns[1].range shouldBe 2..17
+        colorRuns[1].value shouldBe TextColor.Unspecified
+        colorRuns[2].range shouldBe 18..19
+        colorRuns[2].value shouldBe TextColor.Blue
+    }
+
+    @Test
+    fun `edit block handles empty spans and no-op correctly`() {
+        val original = RichString("hello").edit { setAttribute(ColorAttributeKey, TextColor.Red) }
+        val edited =
+            original.edit {
+                // Do nothing
+            }
+
+        edited.text shouldBe original.text
+        edited.getSpans() shouldBe original.getSpans()
     }
 }

--- a/core/src/test/kotlin/dev/mkeeda/arranger/core/text/TestAttributes.kt
+++ b/core/src/test/kotlin/dev/mkeeda/arranger/core/text/TestAttributes.kt
@@ -21,9 +21,3 @@ internal val AttributeContainer.mention: String
 
 internal val AttributeContainer.textColor: TextColor
     get() = getOrDefault(ColorAttributeKey)
-
-internal fun AttributeContainer.plusMention(username: String): AttributeContainer =
-    plus(MentionAttributeKey, username)
-
-internal fun AttributeContainer.plusTextColor(color: TextColor): AttributeContainer =
-    plus(ColorAttributeKey, color)

--- a/core/src/test/kotlin/dev/mkeeda/arranger/core/text/TestAttributes.kt
+++ b/core/src/test/kotlin/dev/mkeeda/arranger/core/text/TestAttributes.kt
@@ -22,8 +22,8 @@ internal val AttributeContainer.mention: String
 internal val AttributeContainer.textColor: TextColor
     get() = getOrDefault(ColorAttributeKey)
 
-internal fun AttributeContainer.withMention(username: String): AttributeContainer =
-    with(MentionAttributeKey, username)
+internal fun AttributeContainer.plusMention(username: String): AttributeContainer =
+    plus(MentionAttributeKey, username)
 
-internal fun AttributeContainer.withTextColor(color: TextColor): AttributeContainer =
-    with(ColorAttributeKey, color)
+internal fun AttributeContainer.plusTextColor(color: TextColor): AttributeContainer =
+    plus(ColorAttributeKey, color)


### PR DESCRIPTION
### Overview
This pull request implements the standard "Runs API" for intuitive text attribute querying, alongside a robust builder DSL (`edit` block) to perform state updates safely. It establishes a consistent interface for attribute manipulation, cleanly moving away from the legacy chain pattern of `.with(...)` methods. 

### Implementation Details
- **`RichRun` and `runs` query API**: Added a coalescing structure to combine contiguous text spans carrying identical text attributes, ignoring unrelated interval splits.
- **`RichStringBuilder` DSL**: Standardized update transactions into an immutable `.edit { ... }` block structure with `setAttribute` and `removeAttribute`.
- **`AttributeContainer` Operator Standardization**: Replaced the legacy `with` method with Kotlin standard `plus` operator, and newly added the `minus` operator for idiomacy.
- **`attributeContainerOf` Factory**: Provided fully type-safe initialization blocks mimicking map creation for cleaner object instantiations.
- Removed legacy `RichString.with` methods and consolidated the underlying interval chunk-merge algorithm into a robust `transformSpans` implementation.