### PR TITLE
docs: update README with WIP notice, usage example, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ fun ArrangerExample() {
     * Seamlessly align with `TextFieldState`'s native Undo/Redo to accurately restore historical attribute ranges.
 - [ ] **8. Performance Tuning**
     * Optimize internal data structures to production-grade performance variants (e.g., Rope or Piece Table) for large text handling.
+- [ ] **9. Kotlin Multiplatform (KMP) Support**
+    * Ensure the core data structures, state management, and formatting logic are fully platform-agnostic to support Compose Multiplatform distribution (iOS, Desktop, Web).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ fun ArrangerExample() {
 }
 ```
 
-### Development Roadmap
+## Development Roadmap
 
 - [x] **1. Core Data Structures (The Core)**
     * Implementation of a range-based data structure (e.g., Interval Tree) to manage attributes by range rather than character indices.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Arranger - Type-safe Rich Text for Jetpack Compose
 
+> [!WARNING]
+> **Work In Progress**: This library is currently under active development. APIs are unstable and subject to change without notice.
+
 ## Project Vision
 The goal of "Arranger" is to provide a "declarative, type-safe, and immutable string manipulation experience similar to SwiftUI's `AttributedString`" to Jetpack Compose and Kotlin Multiplatform (KMP). We aim to break away from the tedious, error-prone index manipulations required by the existing `AnnotatedString` and the traditional WYSIWYG approaches.
 
@@ -28,10 +31,74 @@ To ensure scalability up to PC-class text sizes and pure Kotlin compatibility (K
 ### Compose UI Layer
 * **`RichTextState`**: Wraps `TextFieldState` and holds the `AttributeRangedTree`. It acts as the single source of truth.
 * **`RichTextOutputTransformation`**: Converts the plain text and internal attribute tree into Compose's `AnnotatedString` purely at render time.
-* **`ArrangerEditor`**: A simple, declarative Composable wrapping `BasicTextField` with our state and transformation.
+* **`RichTextEditor`**: A simple, declarative Composable wrapping `BasicTextField` with our state and transformation.
 
-## Roadmap
-* **The Core (Pure Kotlin):** Build the `RichTextBuffer` abstraction, `AttributeRangedTree`, and `AttributeKey` infrastructure.
-* **Runs API:** Implement logic to chunk strings into semantic `RichRun` iterators.
-* **Compose Integration:** Hook into `TextFieldBuffer` changes to shift/update the attribute tree indices reliably.
-* **Formatting Constraints:** Implement clipboard parsing and filtering using `InputTransformation`.
+## Quick Start (Current Usage)
+
+```kotlin
+// 1. Define custom Attribute Keys
+object BoldAttributeKey : AttributeKey<Unit>
+object LinkAttributeKey : AttributeKey<String>
+
+@Composable
+fun ArrangerExample() {
+    // 2. Initialize RichTextState
+    val state = remember { 
+        RichTextState(
+            initialRichString = RichString(
+                text = "Hello Arranger!",
+                attributes = attributeContainerOf(BoldAttributeKey to Unit)
+            )
+        ) 
+    }
+
+    // 3. Declaratively map domain Attributes to Compose UI Styles
+    val styleResolver = remember {
+        AttributeStyleResolver {
+            spanStyle(BoldAttributeKey) {
+                SpanStyle(fontWeight = FontWeight.Bold)
+            }
+            spanStyle<String>(LinkAttributeKey) { url ->
+                SpanStyle(color = Color.Blue, textDecoration = TextDecoration.Underline)
+            }
+        }
+    }
+
+    // 4. Render and Edit natively via Compose 1.7
+    RichTextEditor(
+        state = state,
+        styleResolver = styleResolver,
+        textStyle = TextStyle(fontSize = 16.sp)
+    )
+
+    // 5. Safely modify attributes using the edit DSL
+    Button(onClick = {
+        state.edit {
+            setAttribute(key = LinkAttributeKey, value = "https://example.com", range = 0..4)
+        }
+    }) {
+        Text("Make 'Hello' a Link")
+    }
+}
+```
+
+### Development Roadmap
+
+- [x] **1. Core Data Structures (The Core)**
+    * Implementation of a range-based data structure (e.g., Interval Tree) to manage attributes by range rather than character indices.
+    * Foundation setup for `AttributeKey` and extension properties.
+- [x] **2. Runs API Implementation**
+    * Logic to segment strings into semantic chunks (`RichRun`) that can be operated on as an iterator.
+- [x] **3. Integration with TextFieldState / OutputTransformation**
+    * Logic to hook into `TextFieldBuffer` modifications (insertions/deletions) and dynamically track/shift the indices of the underlying attribute tree.
+- [ ] **4. Implementation of Basic Built-in AttributeKeys**
+    * Basic character-level decorations (e.g., Bold, Text Color, Underline, Italics, Font Size).
+    * Paragraph-level decorations (e.g., Headings, Bullet Lists).
+- [ ] **5. Custom Attribute Mapping APIs**
+    * Expose mechanisms allowing developers to customize how default `AttributeKey`s are translated into Compose `AnnotatedString` styles.
+- [ ] **6. Declarative Formatting Constraints**
+    * Mechanism leveraging `InputTransformation` to parse pasted clipboard HTML/RichText and strictly filter allowed attributes based on an access list.
+- [ ] **7. Full Attribute Restoration on Undo/Redo**
+    * Seamlessly align with `TextFieldState`'s native Undo/Redo to accurately restore historical attribute ranges.
+- [ ] **8. Performance Tuning**
+    * Optimize internal data structures to production-grade performance variants (e.g., Rope or Piece Table) for large text handling.


### PR DESCRIPTION
## Overview
This PR updates the `README.md` to better reflect the current progress and state of the library.

## Changes Included
- **Work In Progress Notice**: Added a standard GitHub alert at the top to clearly indicate the repository is under active, unstable development.
- **Current Usage Example**: Added a realistic Compose snippet combining `RichTextState`, `AttributeStyleResolver`, and the newly implemented `RichTextEditor` to provide a clear picture of how to use Arranger today.
- **Roadmap Update**: Translated the development roadmap into English to align with the repository's language policies, and checked off steps 1 through 3 to showcase the project's completed milestones.