### PR TITLE
refactor(richtext): simplify RichString by exposing spans as public property and making it a data class

### DIFF
--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
@@ -80,7 +80,7 @@ private class RichTextOutputTransformation(
     private val styleResolver: AttributeStyleResolver,
 ) : OutputTransformation {
     override fun TextFieldBuffer.transformOutput() {
-        for (span in state.richString.getSpans()) {
+        for (span in state.richString.spans) {
             val resolved = styleResolver.resolve(span.attributes)
 
             // Determine boundaries avoiding out of bounds in case of race conditions or text shrinkage mid-frame.

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -14,7 +14,7 @@ public class RichTextState(initialText: RichString) {
     internal val textFieldState = TextFieldState(initialText.text)
 
     // The Single Source of Truth for spans
-    private var spans: List<RichSpan> by mutableStateOf(initialText.getSpans())
+    private var spans: List<RichSpan> by mutableStateOf(initialText.spans)
 
     // Computed property representing the complete rich text state
     public val richString: RichString
@@ -25,7 +25,7 @@ public class RichTextState(initialText: RichString) {
             )
 
     public fun edit(block: RichStringBuilder.() -> Unit) {
-        spans = richString.edit(block).getSpans()
+        spans = richString.edit(block).spans
     }
 
     @OptIn(ExperimentalFoundationApi::class)

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -53,7 +53,7 @@ class RichTextEditorTest {
         val expectedNewText = "Welcome aArranger!"
         state.richString.text shouldBe expectedNewText
 
-        val newSpans = state.richString.getSpans()
+        val newSpans = state.richString.spans
         newSpans.size shouldBe 1
 
         // Assert the span accurately shifted

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -42,7 +42,7 @@ class RichTextStateTest {
         val expectedText = "Oh, Hello World"
         state.richString.text shouldBe expectedText
 
-        val spans = state.richString.getSpans()
+        val spans = state.richString.spans
         spans.size shouldBe 1
         spans.first().range shouldBe expectedText.rangeOf("World")
     }
@@ -65,7 +65,7 @@ class RichTextStateTest {
         val expectedText = "Hello Wor!ld"
         state.richString.text shouldBe expectedText
 
-        val spans = state.richString.getSpans()
+        val spans = state.richString.spans
         spans.size shouldBe 1
         spans.first().range shouldBe expectedText.rangeOf("Wor!ld")
     }
@@ -88,7 +88,7 @@ class RichTextStateTest {
         val expectedText = "Hello World!"
         state.richString.text shouldBe expectedText
 
-        val spans = state.richString.getSpans()
+        val spans = state.richString.spans
         spans.size shouldBe 1
         spans.first().range shouldBe expectedText.rangeOf("Hello")
     }
@@ -111,7 +111,7 @@ class RichTextStateTest {
         val expectedText = "Hello World"
         state.richString.text shouldBe expectedText
 
-        val spans = state.richString.getSpans()
+        val spans = state.richString.spans
         spans.size shouldBe 1
         spans.first().range shouldBe expectedText.rangeOf("World")
     }
@@ -134,7 +134,7 @@ class RichTextStateTest {
         val expectedText = "Hello World"
         state.richString.text shouldBe expectedText
 
-        val spans = state.richString.getSpans()
+        val spans = state.richString.spans
         spans.size shouldBe 1
         spans.first().range shouldBe expectedText.rangeOf("World")
     }
@@ -157,7 +157,7 @@ class RichTextStateTest {
         val expectedText = "Hello "
         state.richString.text shouldBe expectedText
 
-        val spans = state.richString.getSpans()
+        val spans = state.richString.spans
         spans.isEmpty() shouldBe true
     }
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
@@ -7,6 +7,7 @@ package dev.mkeeda.arranger.richtext
  * All mutating operations return a new [RichString] instance, preserving the original unchanged.
  *
  * @property text The plain text content.
+ * @property spans A list of all [RichSpan]s currently held by this [RichString].
  */
 public data class RichString(
     public val text: String,

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
@@ -10,7 +10,7 @@ package dev.mkeeda.arranger.richtext
  */
 public class RichString(
     public val text: String,
-    private val spans: List<RichSpan> = emptyList(),
+    public val spans: List<RichSpan> = emptyList(),
 ) {
     /**
      * Creates a new [RichString] having the given [initialAttributes] applied to the entire text.
@@ -24,11 +24,6 @@ public class RichString(
                 listOf(RichSpan(range = text.indices, attributes = initialAttributes))
             },
     )
-
-    /**
-     * Returns a snapshot of all [RichSpan]s currently held by this [RichString].
-     */
-    public fun getSpans(): List<RichSpan> = spans
 
     /**
      * Retrieves all contiguous runs of the requested attribute [key], merging internally split spans.

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
@@ -8,7 +8,7 @@ package dev.mkeeda.arranger.richtext
  *
  * @property text The plain text content.
  */
-public class RichString(
+public data class RichString(
     public val text: String,
     public val spans: List<RichSpan> = emptyList(),
 ) {

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScopeTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScopeTest.kt
@@ -16,7 +16,7 @@ class AttributeEditScopeTest {
                 }
             }
 
-        val spans = str.getSpans()
+        val spans = str.spans
         spans.size shouldBe 1
         val attrs = spans.first().attributes
         attrs.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
@@ -42,7 +42,7 @@ class AttributeEditScopeTest {
                 }
             }
 
-        val spans = str.getSpans()
+        val spans = str.spans
         spans.size shouldBe 1
         val secondSpan = spans.first()
 
@@ -60,7 +60,7 @@ class AttributeEditScopeTest {
                     bold()
                 }
             }
-        val spans = str.getSpans()
+        val spans = str.spans
         spans.size shouldBe 1
         spans[0].range shouldBe 0..4
         spans[0].attributes.getOrNull(BoldKey) shouldBe Unit
@@ -72,14 +72,14 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { textColor(RgbaColor(0xFFFF0000)) }
             }
-        str.getSpans()[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        str.spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
 
         // Passing Unspecified should clear it
         str =
             str.edit {
                 editAttributes { textColor(RgbaColor.Unspecified) }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
 
         // clearTextColor() should clear it
         str =
@@ -90,7 +90,7 @@ class AttributeEditScopeTest {
             str.edit {
                 editAttributes { clearTextColor() }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
     }
 
     @Test
@@ -99,13 +99,13 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { backgroundColor(RgbaColor(0xFF00FF00)) }
             }
-        str.getSpans()[0].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        str.spans[0].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
 
         str =
             str.edit {
                 editAttributes { backgroundColor(RgbaColor.Unspecified) }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
 
         str =
             str.edit {
@@ -115,7 +115,7 @@ class AttributeEditScopeTest {
             str.edit {
                 editAttributes { clearBackgroundColor() }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
     }
 
     @Test
@@ -124,13 +124,13 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { fontSize(TextSize(16f)) }
             }
-        str.getSpans()[0].attributes.getOrNull(FontSizeKey) shouldBe TextSize(16f)
+        str.spans[0].attributes.getOrNull(FontSizeKey) shouldBe TextSize(16f)
 
         str =
             str.edit {
                 editAttributes { fontSize(TextSize.Unspecified) }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
 
         str =
             str.edit {
@@ -140,7 +140,7 @@ class AttributeEditScopeTest {
             str.edit {
                 editAttributes { clearFontSize() }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
     }
 
     @Test
@@ -149,13 +149,13 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { bold() }
             }
-        str.getSpans()[0].attributes.getOrNull(BoldKey) shouldBe Unit
+        str.spans[0].attributes.getOrNull(BoldKey) shouldBe Unit
 
         str =
             str.edit {
                 editAttributes { clearBold() }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
     }
 
     @Test
@@ -164,13 +164,13 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { underline() }
             }
-        str.getSpans()[0].attributes.getOrNull(UnderlineKey) shouldBe Unit
+        str.spans[0].attributes.getOrNull(UnderlineKey) shouldBe Unit
 
         str =
             str.edit {
                 editAttributes { clearUnderline() }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
     }
 
     @Test
@@ -179,13 +179,13 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { italic() }
             }
-        str.getSpans()[0].attributes.getOrNull(ItalicKey) shouldBe Unit
+        str.spans[0].attributes.getOrNull(ItalicKey) shouldBe Unit
 
         str =
             str.edit {
                 editAttributes { clearItalic() }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
     }
 
     @Test
@@ -194,12 +194,12 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { strikethrough() }
             }
-        str.getSpans()[0].attributes.getOrNull(StrikethroughKey) shouldBe Unit
+        str.spans[0].attributes.getOrNull(StrikethroughKey) shouldBe Unit
 
         str =
             str.edit {
                 editAttributes { clearStrikethrough() }
             }
-        str.getSpans().isEmpty() shouldBe true
+        str.spans.isEmpty() shouldBe true
     }
 }

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringTest.kt
@@ -25,11 +25,11 @@ class RichStringTest {
 
         // The original remains unchanged
         original.text shouldBe "Hello"
-        original.getSpans().shouldBeEmpty()
+        original.spans.shouldBeEmpty()
 
         // The styled instance has the attribute applied to the full range
         styled.text shouldBe "Hello"
-        val spans = styled.getSpans()
+        val spans = styled.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..4
         spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
@@ -42,7 +42,7 @@ class RichStringTest {
                 .edit { setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 0..4) }
 
         richString.text shouldBe "Hello, World!"
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..4
         spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
@@ -58,7 +58,7 @@ class RichStringTest {
                 }
 
         richString.text shouldBe "Hello, World!"
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 2
 
         val colorSpan =
@@ -112,7 +112,7 @@ class RichStringTest {
             RichString(text = "Hello")
                 .edit { setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 3..3) }
 
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 3..3
         spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
@@ -132,7 +132,7 @@ class RichStringTest {
                     setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 5..15)
                 }
 
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 3
 
         spans[0].range shouldBe 0..4
@@ -162,7 +162,7 @@ class RichStringTest {
                     setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 3..7)
                 }
 
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 3
 
         spans[0].range shouldBe 0..2
@@ -188,7 +188,7 @@ class RichStringTest {
                 }
 
         // It should perfectly replace the attribute and optimize back to 1 span
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..10
         spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
@@ -213,7 +213,7 @@ class RichStringTest {
                     setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 2..10)
                 }
 
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 5
 
         spans[0].range shouldBe 0..1
@@ -241,7 +241,7 @@ class RichStringTest {
                     setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 5..10)
                 }
 
-        val spans = richString.getSpans()
+        val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..10
         spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
@@ -264,7 +264,7 @@ class RichStringTest {
                 }
 
         // There should be 4 internal spans: [0..4], [5..9], [10..15], [16..19]
-        richString.getSpans() shouldHaveSize 4
+        richString.spans shouldHaveSize 4
 
         val mentionRuns = richString.runs(BackgroundColorKey)
 
@@ -325,8 +325,8 @@ class RichStringTest {
             }
 
         // Original remains completely unchanged
-        original.getSpans() shouldHaveSize 2
-        original.getSpans()[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        original.spans shouldHaveSize 2
+        original.spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
 
         // Edited contains the new attributes
         edited.runs(BackgroundColorKey)[0].range shouldBe 5..14
@@ -356,6 +356,6 @@ class RichStringTest {
             }
 
         edited.text shouldBe original.text
-        edited.getSpans() shouldBe original.getSpans()
+        edited.spans shouldBe original.spans
     }
 }


### PR DESCRIPTION
## Overview
This PR simplifies the `RichString` implementation and improves its behavior as a Compose state value by making it a data class.

## Implementation Details
- Changed `private val spans` to `public val spans` in `RichString` and removed the custom `getSpans()` method to leverage Kotlin's built-in property getters.
- Updated all call sites across the project (`RichTextState`, `RichTextEditor`, and tests) to directly access the `.spans` property instead of calling `getSpans()`.
- Added the `data` modifier to `RichString`, which automatically generates `equals()` and `hashCode()`. This ensures structural equality, which is critical for preventing unnecessary recompositions when used as state in Jetpack Compose, and also improves debugging through the generated `toString()`.