### PR TITLE
chore(ci): update upload-artifact action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./gradlew lint spotlessCheck testDebugUnitTest
 
       - name: Upload Verification Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: verification-reports


### PR DESCRIPTION
## Overview
Updated the `actions/upload-artifact` in the CI workflow to its latest version (`v7`) to resolve deprecation warnings.

## Implementation Details
- Modified `.github/workflows/ci.yml`
- Bumped `actions/upload-artifact` from `v4` to `v7`