### PR TITLE
refactor(richtext): introduce SpanAttributeKey and ParagraphAttributeKey for type safety

### DIFF
--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolver.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolver.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import dev.mkeeda.arranger.richtext.AttributeContainer
 import dev.mkeeda.arranger.richtext.AttributeKey
+import dev.mkeeda.arranger.richtext.ParagraphAttributeKey
 
 /**
  * A container representing the resolved visual styles for a set of attributes.
@@ -84,7 +85,7 @@ public class AttributeStyleBuilder internal constructor() {
      * When the [AttributeContainer] contains this key, the [mapper] is invoked with the key's value.
      */
     public fun <T> paragraphStyle(
-        key: AttributeKey<T>,
+        key: ParagraphAttributeKey<T>,
         mapper: (T) -> ParagraphStyle,
     ) {
         paragraphResolvers.add { container ->

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolverTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolverTest.kt
@@ -6,7 +6,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
-import dev.mkeeda.arranger.richtext.AttributeKey
+import dev.mkeeda.arranger.richtext.ParagraphAttributeKey
+import dev.mkeeda.arranger.richtext.SpanAttributeKey
 import dev.mkeeda.arranger.richtext.attributeContainerOf
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -16,17 +17,17 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class AttributeStyleResolverTest {
-    private object TestSpanKey : AttributeKey<String> {
+    private object TestSpanKey : SpanAttributeKey<String> {
         override val name: String = "TestSpan"
         override val defaultValue: String = ""
     }
 
-    private object TestParagraphKey : AttributeKey<TextAlign> {
+    private object TestParagraphKey : ParagraphAttributeKey<TextAlign> {
         override val name: String = "TestParagraph"
         override val defaultValue: TextAlign = TextAlign.Unspecified
     }
 
-    private object TestCombinedKey : AttributeKey<Unit> {
+    private object TestCombinedKey : ParagraphAttributeKey<Unit> {
         override val name: String = "TestCombined"
         override val defaultValue: Unit = Unit
     }

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolverTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolverTest.kt
@@ -27,7 +27,7 @@ class AttributeStyleResolverTest {
         override val defaultValue: TextAlign = TextAlign.Unspecified
     }
 
-    private object TestCombinedKey : ParagraphAttributeKey<Unit> {
+    private object TestParagraphAndSpanKey : ParagraphAttributeKey<Unit> {
         override val name: String = "TestCombined"
         override val defaultValue: Unit = Unit
     }
@@ -40,10 +40,10 @@ class AttributeStyleResolverTest {
             paragraphStyle(TestParagraphKey) { align ->
                 ParagraphStyle(textAlign = align)
             }
-            spanStyle(TestCombinedKey) {
+            spanStyle(TestParagraphAndSpanKey) {
                 SpanStyle(fontWeight = FontWeight.Bold)
             }
-            paragraphStyle(TestCombinedKey) {
+            paragraphStyle(TestParagraphAndSpanKey) {
                 ParagraphStyle(lineHeight = 24.sp)
             }
         }
@@ -54,14 +54,14 @@ class AttributeStyleResolverTest {
             attributeContainerOf(
                 TestSpanKey to "FFFF0000",
                 TestParagraphKey to TextAlign.Center,
-                TestCombinedKey to Unit,
+                TestParagraphAndSpanKey to Unit,
             )
 
         val resolved = resolver.resolve(container)
         resolved.spanStyle?.color shouldBe Color(0xFFFF0000)
-        resolved.spanStyle?.fontWeight shouldBe FontWeight.Bold // From TestCombinedKey
+        resolved.spanStyle?.fontWeight shouldBe FontWeight.Bold // From TestParagraphAndSpanKey
         resolved.paragraphStyle?.textAlign shouldBe TextAlign.Center
-        resolved.paragraphStyle?.lineHeight shouldBe 24.sp // From TestCombinedKey
+        resolved.paragraphStyle?.lineHeight shouldBe 24.sp // From TestParagraphAndSpanKey
     }
 
     @Test
@@ -85,7 +85,7 @@ class AttributeStyleResolverTest {
 
     @Test
     fun `resolve returns matching span and paragraph styles when combined attribute matches`() {
-        val container = attributeContainerOf(TestCombinedKey to Unit)
+        val container = attributeContainerOf(TestParagraphAndSpanKey to Unit)
         val resolved = resolver.resolve(container)
 
         resolved.spanStyle?.fontWeight shouldBe FontWeight.Bold
@@ -96,12 +96,12 @@ class AttributeStyleResolverTest {
     fun `AttributeStyleResolver allows custom resolver to override base default`() {
         val overridingResolver =
             AttributeStyleResolver(base = resolver) {
-                spanStyle(TestCombinedKey) {
+                spanStyle(TestParagraphAndSpanKey) {
                     SpanStyle(fontWeight = FontWeight.Normal)
                 }
             }
 
-        val container = attributeContainerOf(TestCombinedKey to Unit)
+        val container = attributeContainerOf(TestParagraphAndSpanKey to Unit)
         val resolved = overridingResolver.resolve(container)
 
         // Custom resolver overrides the base

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -29,7 +29,7 @@ class RichTextEditorTest {
                 initialText =
                     RichString(text = initialText).edit {
                         // "Arranger!" is length 9, at index 11
-                        setAttribute(BoldKey, Unit, range = initialText.rangeOf("Arranger!"))
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("Arranger!"))
                     },
             )
 

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -31,7 +31,7 @@ class RichTextStateTest {
             RichTextState(
                 initialText =
                     RichString(text = initialText).edit {
-                        setAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
                     },
             )
 
@@ -54,7 +54,7 @@ class RichTextStateTest {
             RichTextState(
                 initialText =
                     RichString(text = initialText).edit {
-                        setAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
                     },
             )
 
@@ -77,7 +77,7 @@ class RichTextStateTest {
             RichTextState(
                 initialText =
                     RichString(text = initialText).edit {
-                        setAttribute(BoldKey, Unit, range = initialText.rangeOf("Hello"))
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("Hello"))
                     },
             )
 
@@ -100,7 +100,7 @@ class RichTextStateTest {
             RichTextState(
                 initialText =
                     RichString(text = initialText).edit {
-                        setAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
                     },
             )
 
@@ -123,7 +123,7 @@ class RichTextStateTest {
             RichTextState(
                 initialText =
                     RichString(text = initialText).edit {
-                        setAttribute(BoldKey, Unit, range = initialText.rangeOf("Wor!ld"))
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("Wor!ld"))
                     },
             )
 
@@ -146,7 +146,7 @@ class RichTextStateTest {
             RichTextState(
                 initialText =
                     RichString(text = initialText).edit {
-                        setAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
                     },
             )
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
@@ -12,7 +12,7 @@ public class AttributeEditScope internal constructor(
      * If [value] is null, the attribute is removed from the specified range.
      */
     public fun <T : Any> set(
-        key: AttributeKey<T>,
+        key: SpanAttributeKey<T>,
         value: T?,
     ) {
         if (value == null) {
@@ -27,7 +27,7 @@ public class AttributeEditScope internal constructor(
      * The underlying range is automatically snapped to paragraph boundaries.
      */
     public fun <T : Any> setParagraph(
-        key: AttributeKey<T>,
+        key: ParagraphAttributeKey<T>,
         value: T?,
     ) {
         if (value == null) {

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
@@ -11,7 +11,7 @@ public class AttributeEditScope internal constructor(
      * Sets or removes a character span attribute for the given [key].
      * If [value] is null, the span attribute is removed from the specified range.
      */
-    public fun <T : Any> setSpan(
+    public fun <T : Any> setSpanAttribute(
         key: SpanAttributeKey<T>,
         value: T?,
     ) {
@@ -26,7 +26,7 @@ public class AttributeEditScope internal constructor(
      * Sets or removes a paragraph-level attribute for the given [key].
      * The underlying range is automatically snapped to paragraph boundaries.
      */
-    public fun <T : Any> setParagraph(
+    public fun <T : Any> setParagraphAttribute(
         key: ParagraphAttributeKey<T>,
         value: T?,
     ) {
@@ -45,7 +45,7 @@ public fun AttributeEditScope.textColor(color: RgbaColor) {
     if (color == RgbaColor.Unspecified) {
         clearTextColor()
     } else {
-        setSpan(TextColorKey, color)
+        setSpanAttribute(TextColorKey, color)
     }
 }
 
@@ -53,7 +53,7 @@ public fun AttributeEditScope.textColor(color: RgbaColor) {
  * Convenience function to remove the text color attribute in the range.
  */
 public fun AttributeEditScope.clearTextColor() {
-    setSpan(TextColorKey, null)
+    setSpanAttribute(TextColorKey, null)
 }
 
 /**
@@ -63,7 +63,7 @@ public fun AttributeEditScope.backgroundColor(color: RgbaColor) {
     if (color == RgbaColor.Unspecified) {
         clearBackgroundColor()
     } else {
-        setSpan(BackgroundColorKey, color)
+        setSpanAttribute(BackgroundColorKey, color)
     }
 }
 
@@ -71,7 +71,7 @@ public fun AttributeEditScope.backgroundColor(color: RgbaColor) {
  * Convenience function to remove the background color attribute in the range.
  */
 public fun AttributeEditScope.clearBackgroundColor() {
-    setSpan(BackgroundColorKey, null)
+    setSpanAttribute(BackgroundColorKey, null)
 }
 
 /**
@@ -81,7 +81,7 @@ public fun AttributeEditScope.fontSize(size: TextSize) {
     if (size == TextSize.Unspecified) {
         clearFontSize()
     } else {
-        setSpan(FontSizeKey, size)
+        setSpanAttribute(FontSizeKey, size)
     }
 }
 
@@ -89,63 +89,63 @@ public fun AttributeEditScope.fontSize(size: TextSize) {
  * Convenience function to remove the font size attribute in the range.
  */
 public fun AttributeEditScope.clearFontSize() {
-    setSpan(FontSizeKey, null)
+    setSpanAttribute(FontSizeKey, null)
 }
 
 /**
  * Convenience function to apply the bold text attribute within this builder.
  */
 public fun AttributeEditScope.bold() {
-    setSpan(BoldKey, Unit)
+    setSpanAttribute(BoldKey, Unit)
 }
 
 /**
  * Convenience function to remove the bold attribute in the range.
  */
 public fun AttributeEditScope.clearBold() {
-    setSpan(BoldKey, null)
+    setSpanAttribute(BoldKey, null)
 }
 
 /**
  * Convenience function to apply the underline text attribute within this builder.
  */
 public fun AttributeEditScope.underline() {
-    setSpan(UnderlineKey, Unit)
+    setSpanAttribute(UnderlineKey, Unit)
 }
 
 /**
  * Convenience function to remove the underline attribute in the range.
  */
 public fun AttributeEditScope.clearUnderline() {
-    setSpan(UnderlineKey, null)
+    setSpanAttribute(UnderlineKey, null)
 }
 
 /**
  * Convenience function to apply the italic text attribute within this builder.
  */
 public fun AttributeEditScope.italic() {
-    setSpan(ItalicKey, Unit)
+    setSpanAttribute(ItalicKey, Unit)
 }
 
 /**
  * Convenience function to remove the italic attribute in the range.
  */
 public fun AttributeEditScope.clearItalic() {
-    setSpan(ItalicKey, null)
+    setSpanAttribute(ItalicKey, null)
 }
 
 /**
  * Convenience function to apply the strikethrough text attribute within this builder.
  */
 public fun AttributeEditScope.strikethrough() {
-    setSpan(StrikethroughKey, Unit)
+    setSpanAttribute(StrikethroughKey, Unit)
 }
 
 /**
  * Convenience function to remove the strikethrough attribute in the range.
  */
 public fun AttributeEditScope.clearStrikethrough() {
-    setSpan(StrikethroughKey, null)
+    setSpanAttribute(StrikethroughKey, null)
 }
 
 /**
@@ -153,14 +153,14 @@ public fun AttributeEditScope.clearStrikethrough() {
  * The applied range will automatically snap to paragraph boundaries.
  */
 public fun AttributeEditScope.headingLevel(level: HeadingLevel?) {
-    setParagraph(HeadingKey, level)
+    setParagraphAttribute(HeadingKey, level)
 }
 
 /**
  * Convenience function to remove the heading attribute in the range.
  */
 public fun AttributeEditScope.clearHeadingLevel() {
-    setParagraph(HeadingKey, null)
+    setParagraphAttribute(HeadingKey, null)
 }
 
 /**
@@ -168,14 +168,14 @@ public fun AttributeEditScope.clearHeadingLevel() {
  * The applied range will automatically snap to paragraph boundaries.
  */
 public fun AttributeEditScope.textAlignment(alignment: TextAlignment?) {
-    setParagraph(TextAlignmentKey, alignment)
+    setParagraphAttribute(TextAlignmentKey, alignment)
 }
 
 /**
  * Convenience function to remove the text alignment attribute in the range.
  */
 public fun AttributeEditScope.clearTextAlignment() {
-    setParagraph(TextAlignmentKey, null)
+    setParagraphAttribute(TextAlignmentKey, null)
 }
 
 /**
@@ -183,12 +183,12 @@ public fun AttributeEditScope.clearTextAlignment() {
  * The applied range will automatically snap to paragraph boundaries.
  */
 public fun AttributeEditScope.blockquote() {
-    setParagraph(BlockquoteKey, Unit)
+    setParagraphAttribute(BlockquoteKey, Unit)
 }
 
 /**
  * Convenience function to remove the blockquote attribute in the range.
  */
 public fun AttributeEditScope.clearBlockquote() {
-    setParagraph(BlockquoteKey, null)
+    setParagraphAttribute(BlockquoteKey, null)
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
@@ -8,10 +8,10 @@ public class AttributeEditScope internal constructor(
     private val range: IntRange,
 ) {
     /**
-     * Sets or removes an attribute for the given [key].
-     * If [value] is null, the attribute is removed from the specified range.
+     * Sets or removes a character span attribute for the given [key].
+     * If [value] is null, the span attribute is removed from the specified range.
      */
-    public fun <T : Any> set(
+    public fun <T : Any> setSpan(
         key: SpanAttributeKey<T>,
         value: T?,
     ) {
@@ -45,7 +45,7 @@ public fun AttributeEditScope.textColor(color: RgbaColor) {
     if (color == RgbaColor.Unspecified) {
         clearTextColor()
     } else {
-        set(TextColorKey, color)
+        setSpan(TextColorKey, color)
     }
 }
 
@@ -53,7 +53,7 @@ public fun AttributeEditScope.textColor(color: RgbaColor) {
  * Convenience function to remove the text color attribute in the range.
  */
 public fun AttributeEditScope.clearTextColor() {
-    set(TextColorKey, null)
+    setSpan(TextColorKey, null)
 }
 
 /**
@@ -63,7 +63,7 @@ public fun AttributeEditScope.backgroundColor(color: RgbaColor) {
     if (color == RgbaColor.Unspecified) {
         clearBackgroundColor()
     } else {
-        set(BackgroundColorKey, color)
+        setSpan(BackgroundColorKey, color)
     }
 }
 
@@ -71,7 +71,7 @@ public fun AttributeEditScope.backgroundColor(color: RgbaColor) {
  * Convenience function to remove the background color attribute in the range.
  */
 public fun AttributeEditScope.clearBackgroundColor() {
-    set(BackgroundColorKey, null)
+    setSpan(BackgroundColorKey, null)
 }
 
 /**
@@ -81,7 +81,7 @@ public fun AttributeEditScope.fontSize(size: TextSize) {
     if (size == TextSize.Unspecified) {
         clearFontSize()
     } else {
-        set(FontSizeKey, size)
+        setSpan(FontSizeKey, size)
     }
 }
 
@@ -89,63 +89,63 @@ public fun AttributeEditScope.fontSize(size: TextSize) {
  * Convenience function to remove the font size attribute in the range.
  */
 public fun AttributeEditScope.clearFontSize() {
-    set(FontSizeKey, null)
+    setSpan(FontSizeKey, null)
 }
 
 /**
  * Convenience function to apply the bold text attribute within this builder.
  */
 public fun AttributeEditScope.bold() {
-    set(BoldKey, Unit)
+    setSpan(BoldKey, Unit)
 }
 
 /**
  * Convenience function to remove the bold attribute in the range.
  */
 public fun AttributeEditScope.clearBold() {
-    set(BoldKey, null)
+    setSpan(BoldKey, null)
 }
 
 /**
  * Convenience function to apply the underline text attribute within this builder.
  */
 public fun AttributeEditScope.underline() {
-    set(UnderlineKey, Unit)
+    setSpan(UnderlineKey, Unit)
 }
 
 /**
  * Convenience function to remove the underline attribute in the range.
  */
 public fun AttributeEditScope.clearUnderline() {
-    set(UnderlineKey, null)
+    setSpan(UnderlineKey, null)
 }
 
 /**
  * Convenience function to apply the italic text attribute within this builder.
  */
 public fun AttributeEditScope.italic() {
-    set(ItalicKey, Unit)
+    setSpan(ItalicKey, Unit)
 }
 
 /**
  * Convenience function to remove the italic attribute in the range.
  */
 public fun AttributeEditScope.clearItalic() {
-    set(ItalicKey, null)
+    setSpan(ItalicKey, null)
 }
 
 /**
  * Convenience function to apply the strikethrough text attribute within this builder.
  */
 public fun AttributeEditScope.strikethrough() {
-    set(StrikethroughKey, Unit)
+    setSpan(StrikethroughKey, Unit)
 }
 
 /**
  * Convenience function to remove the strikethrough attribute in the range.
  */
 public fun AttributeEditScope.clearStrikethrough() {
-    set(StrikethroughKey, null)
+    setSpan(StrikethroughKey, null)
 }
 
 /**

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
@@ -16,9 +16,9 @@ public class AttributeEditScope internal constructor(
         value: T?,
     ) {
         if (value == null) {
-            builder.removeAttribute(key, range)
+            builder.removeSpanAttribute(key, range)
         } else {
-            builder.setAttribute(key, value, range)
+            builder.setSpanAttribute(key, value, range)
         }
     }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
@@ -8,3 +8,13 @@ public interface AttributeKey<T> {
     public val name: String
     public val defaultValue: T
 }
+
+/**
+ * A marker interface indicating that the attribute applies to character spans.
+ */
+public interface SpanAttributeKey<T> : AttributeKey<T>
+
+/**
+ * A marker interface indicating that the attribute applies to whole paragraphs.
+ */
+public interface ParagraphAttributeKey<T> : AttributeKey<T>

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
@@ -4,7 +4,7 @@ package dev.mkeeda.arranger.richtext
  * Interface defining a key for attributes held within RichText.
  * By having a type-safe [defaultValue], it clearly defines the fallback value when an attribute is not set.
  */
-public interface AttributeKey<T> {
+public sealed interface AttributeKey<T> {
     public val name: String
     public val defaultValue: T
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/Attributes.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/Attributes.kt
@@ -30,7 +30,7 @@ public value class TextSize(public val sp: Float) {
 /**
  * The standard [AttributeKey] to denote bold text.
  */
-public object BoldKey : AttributeKey<Unit> {
+public object BoldKey : SpanAttributeKey<Unit> {
     override val name: String = "bold"
     override val defaultValue: Unit = Unit
 }
@@ -38,7 +38,7 @@ public object BoldKey : AttributeKey<Unit> {
 /**
  * The standard [AttributeKey] to denote italic text.
  */
-public object ItalicKey : AttributeKey<Unit> {
+public object ItalicKey : SpanAttributeKey<Unit> {
     override val name: String = "italic"
     override val defaultValue: Unit = Unit
 }
@@ -46,7 +46,7 @@ public object ItalicKey : AttributeKey<Unit> {
 /**
  * The standard [AttributeKey] to denote strikethrough text.
  */
-public object StrikethroughKey : AttributeKey<Unit> {
+public object StrikethroughKey : SpanAttributeKey<Unit> {
     override val name: String = "strikethrough"
     override val defaultValue: Unit = Unit
 }
@@ -54,7 +54,7 @@ public object StrikethroughKey : AttributeKey<Unit> {
 /**
  * The standard [AttributeKey] to denote underlined text.
  */
-public object UnderlineKey : AttributeKey<Unit> {
+public object UnderlineKey : SpanAttributeKey<Unit> {
     override val name: String = "underline"
     override val defaultValue: Unit = Unit
 }
@@ -63,7 +63,7 @@ public object UnderlineKey : AttributeKey<Unit> {
  * The standard [AttributeKey] to denote the foreground text color.
  * Contains a [RgbaColor] when specified, or [RgbaColor.Unspecified] otherwise.
  */
-public object TextColorKey : AttributeKey<RgbaColor> {
+public object TextColorKey : SpanAttributeKey<RgbaColor> {
     override val name: String = "textColor"
     override val defaultValue: RgbaColor = RgbaColor.Unspecified
 }
@@ -72,7 +72,7 @@ public object TextColorKey : AttributeKey<RgbaColor> {
  * The standard [AttributeKey] to denote the background color.
  * Contains a [RgbaColor] when specified, or [RgbaColor.Unspecified] otherwise.
  */
-public object BackgroundColorKey : AttributeKey<RgbaColor> {
+public object BackgroundColorKey : SpanAttributeKey<RgbaColor> {
     override val name: String = "backgroundColor"
     override val defaultValue: RgbaColor = RgbaColor.Unspecified
 }
@@ -81,7 +81,7 @@ public object BackgroundColorKey : AttributeKey<RgbaColor> {
  * The standard [AttributeKey] to denote the font size.
  * Contains a [TextSize] when specified, or [TextSize.Unspecified] otherwise.
  */
-public object FontSizeKey : AttributeKey<TextSize> {
+public object FontSizeKey : SpanAttributeKey<TextSize> {
     override val name: String = "fontSize"
     override val defaultValue: TextSize = TextSize.Unspecified
 }
@@ -102,7 +102,7 @@ public enum class HeadingLevel {
 /**
  * A semantic marker indicating the heading level of the paragraph.
  */
-public object HeadingKey : AttributeKey<HeadingLevel> {
+public object HeadingKey : ParagraphAttributeKey<HeadingLevel> {
     override val name: String = "heading"
     override val defaultValue: HeadingLevel = HeadingLevel.Unspecified
 }
@@ -121,7 +121,7 @@ public enum class TextAlignment {
 /**
  * A semantic marker indicating the horizontal text alignment of the paragraph.
  */
-public object TextAlignmentKey : AttributeKey<TextAlignment> {
+public object TextAlignmentKey : ParagraphAttributeKey<TextAlignment> {
     override val name: String = "textAlignment"
     override val defaultValue: TextAlignment = TextAlignment.Unspecified
 }
@@ -129,7 +129,7 @@ public object TextAlignmentKey : AttributeKey<TextAlignment> {
 /**
  * A semantic marker indicating that the paragraph is a blockquote.
  */
-public object BlockquoteKey : AttributeKey<Unit> {
+public object BlockquoteKey : ParagraphAttributeKey<Unit> {
     override val name: String = "blockquote"
     override val defaultValue: Unit = Unit
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuilder.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuilder.kt
@@ -16,7 +16,7 @@ public class RichStringBuilder internal constructor(
      * Any existing attributes of the same key within this range are completely overwritten.
      */
     public fun <T> setAttribute(
-        key: AttributeKey<T>,
+        key: SpanAttributeKey<T>,
         value: T,
         range: IntRange = 0 until textLength,
     ) {
@@ -31,7 +31,7 @@ public class RichStringBuilder internal constructor(
      * Removes any attributes associated with the specified [key] within the given [range].
      */
     public fun <T> removeAttribute(
-        key: AttributeKey<T>,
+        key: SpanAttributeKey<T>,
         range: IntRange = 0 until textLength,
     ) {
         checkRange(range)
@@ -47,13 +47,16 @@ public class RichStringBuilder internal constructor(
      * it intersects with.
      */
     public fun <T> setParagraphAttribute(
-        key: AttributeKey<T>,
+        key: ParagraphAttributeKey<T>,
         value: T,
         range: IntRange = 0 until textLength,
     ) {
         checkRange(range)
         val snappedRange = range.snapToParagraphs(text)
-        setAttribute(key, value, snappedRange)
+        currentSpans =
+            currentSpans.transformSpans(targetRange = snappedRange) { attributes ->
+                attributes.plus(key, value)
+            }
     }
 
     private fun IntRange.snapToParagraphs(text: String): IntRange {
@@ -74,12 +77,15 @@ public class RichStringBuilder internal constructor(
      * it intersects with.
      */
     public fun <T> removeParagraphAttribute(
-        key: AttributeKey<T>,
+        key: ParagraphAttributeKey<T>,
         range: IntRange = 0 until textLength,
     ) {
         checkRange(range)
         val snappedRange = range.snapToParagraphs(text)
-        removeAttribute(key, snappedRange)
+        currentSpans =
+            currentSpans.transformSpans(targetRange = snappedRange) { attributes ->
+                attributes - key
+            }
     }
 
     /**

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuilder.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuilder.kt
@@ -12,10 +12,10 @@ public class RichStringBuilder internal constructor(
     private val textLength: Int = text.length
 
     /**
-     * Applies the specified attribute [key] and [value] to the given [range].
-     * Any existing attributes of the same key within this range are completely overwritten.
+     * Applies the specified character span attribute [key] and [value] to the given [range].
+     * Any existing span attributes of the same key within this range are completely overwritten.
      */
-    public fun <T> setAttribute(
+    public fun <T> setSpanAttribute(
         key: SpanAttributeKey<T>,
         value: T,
         range: IntRange = 0 until textLength,
@@ -28,9 +28,9 @@ public class RichStringBuilder internal constructor(
     }
 
     /**
-     * Removes any attributes associated with the specified [key] within the given [range].
+     * Removes any character span attributes associated with the specified [key] within the given [range].
      */
-    public fun <T> removeAttribute(
+    public fun <T> removeSpanAttribute(
         key: SpanAttributeKey<T>,
         range: IntRange = 0 until textLength,
     ) {

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditParagraphTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditParagraphTest.kt
@@ -14,11 +14,11 @@ class RichStringEditParagraphTest {
         val actual =
             richString.edit {
                 // Index 8 is 'n' in "Line2"
-                setParagraphAttribute(BoldKey, Unit, 8..8)
+                setParagraphAttribute(BlockquoteKey, Unit, 8..8)
             }
 
         // "Line2" is from index 6 to 10. "Line1\n" is 0..5, "Line2\n" is 6..11.
-        val runs = actual.runs(BoldKey)
+        val runs = actual.runs(BlockquoteKey)
         runs shouldHaveSize 1
         runs[0] shouldBe RichRun(text = "Line2\n", range = 6..11, value = Unit)
     }
@@ -30,10 +30,10 @@ class RichStringEditParagraphTest {
         val actual =
             richString.edit {
                 // Index 0 is 'L' in "Line1"
-                setParagraphAttribute(BoldKey, Unit, 0..0)
+                setParagraphAttribute(BlockquoteKey, Unit, 0..0)
             }
 
-        val runs = actual.runs(BoldKey)
+        val runs = actual.runs(BlockquoteKey)
         runs shouldHaveSize 1
         runs[0] shouldBe RichRun(text = "Line1\n", range = 0..5, value = Unit)
     }
@@ -45,10 +45,10 @@ class RichStringEditParagraphTest {
         val actual =
             richString.edit {
                 // Last index is "Line3"
-                setParagraphAttribute(BoldKey, Unit, paragraphText.lastIndex..paragraphText.lastIndex)
+                setParagraphAttribute(BlockquoteKey, Unit, paragraphText.lastIndex..paragraphText.lastIndex)
             }
 
-        val runs = actual.runs(BoldKey)
+        val runs = actual.runs(BlockquoteKey)
         runs shouldHaveSize 1
         runs[0] shouldBe RichRun(text = "Line3", range = 12..16, value = Unit)
     }
@@ -60,10 +60,10 @@ class RichStringEditParagraphTest {
         val actual =
             richString.edit {
                 // Include 'n' in Line1 (index 2) to 'L' in Line3 (index 12)
-                setParagraphAttribute(BoldKey, Unit, 2..12)
+                setParagraphAttribute(BlockquoteKey, Unit, 2..12)
             }
 
-        val runs = actual.runs(BoldKey)
+        val runs = actual.runs(BlockquoteKey)
         runs shouldHaveSize 1
         runs[0] shouldBe RichRun(text = paragraphText, range = 0..16, value = Unit)
     }

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditSpanTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditSpanTest.kt
@@ -11,7 +11,7 @@ class RichStringEditSpanTest {
     @Test
     fun `applies an attribute to the entire text and returns a new immutable instance`() {
         val original = RichString(text = "Hello")
-        val styled = original.edit { setAttribute(TextColorKey, RgbaColor(0xFFFF0000)) }
+        val styled = original.edit { setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000)) }
 
         // A new instance is returned (immutability)
         styled shouldNotBe original
@@ -32,7 +32,7 @@ class RichStringEditSpanTest {
     fun `applies an attribute to a specific range`() {
         val richString =
             RichString(text = "Hello, World!")
-                .edit { setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 0..4) }
+                .edit { setSpanAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 0..4) }
 
         richString.text shouldBe "Hello, World!"
         val spans = richString.spans
@@ -46,8 +46,8 @@ class RichStringEditSpanTest {
         val richString =
             RichString(text = "Hello, World!")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
-                    setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 7..11)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
+                    setSpanAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 7..11)
                 }
 
         richString.text shouldBe "Hello, World!"
@@ -74,7 +74,7 @@ class RichStringEditSpanTest {
         val richString = RichString(text = "Hello, World!")
         val exception =
             shouldThrow<IllegalArgumentException> {
-                richString.edit { setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = -1..3) }
+                richString.edit { setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = -1..3) }
             }
         exception.message shouldBe "Range start must not be negative: -1"
     }
@@ -84,7 +84,7 @@ class RichStringEditSpanTest {
         val richString = RichString(text = "Hello")
         val exception =
             shouldThrow<IllegalArgumentException> {
-                richString.edit { setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..5) }
+                richString.edit { setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..5) }
             }
         exception.message shouldBe "Range end must be within text bounds: 5 >= 5"
     }
@@ -94,7 +94,7 @@ class RichStringEditSpanTest {
         val richString = RichString(text = "Hello, World!")
         val exception =
             shouldThrow<IllegalArgumentException> {
-                richString.edit { setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 5..3) }
+                richString.edit { setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 5..3) }
             }
         exception.message shouldBe "Range must not be empty: 5..3"
     }
@@ -103,7 +103,7 @@ class RichStringEditSpanTest {
     fun `successfully applies an attribute to a 1-character range`() {
         val richString =
             RichString(text = "Hello")
-                .edit { setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 3..3) }
+                .edit { setSpanAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 3..3) }
 
         val spans = richString.spans
         spans shouldHaveSize 1
@@ -121,8 +121,8 @@ class RichStringEditSpanTest {
         val richString =
             RichString("1234567890123456")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..10)
-                    setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 5..15)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..10)
+                    setSpanAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 5..15)
                 }
 
         val spans = richString.spans
@@ -151,8 +151,8 @@ class RichStringEditSpanTest {
         val richString =
             RichString("12345678901")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..10)
-                    setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 3..7)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..10)
+                    setSpanAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 3..7)
                 }
 
         val spans = richString.spans
@@ -176,8 +176,8 @@ class RichStringEditSpanTest {
         val richString =
             RichString("12345678901")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..10)
-                    setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 0..10)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..10)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 0..10)
                 }
 
         // It should perfectly replace the attribute and optimize back to 1 span
@@ -201,9 +201,9 @@ class RichStringEditSpanTest {
         val richString =
             RichString("1234567890123")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 8..12)
-                    setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 2..10)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 8..12)
+                    setSpanAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 2..10)
                 }
 
         val spans = richString.spans
@@ -230,8 +230,8 @@ class RichStringEditSpanTest {
         val richString =
             RichString("12345678901")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 5..10)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 5..10)
                 }
 
         val spans = richString.spans
@@ -245,18 +245,18 @@ class RichStringEditSpanTest {
         val original =
             RichString("12345678901234567890")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..9)
-                    setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 10..19)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..9)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 10..19)
                 }
 
         val edited =
             original.edit {
                 // Apply mention to the middle
-                setAttribute(BackgroundColorKey, RgbaColor(0xFF00FFFF), range = 5..14)
+                setSpanAttribute(BackgroundColorKey, RgbaColor(0xFF00FFFF), range = 5..14)
                 // Remove the color over a sub-range
-                removeAttribute(TextColorKey, range = 8..11)
+                removeSpanAttribute(TextColorKey, range = 8..11)
                 // Add a completely new attribute spanning across everything
-                setAttribute(TextColorKey, RgbaColor.Unspecified, range = 2..17)
+                setSpanAttribute(TextColorKey, RgbaColor.Unspecified, range = 2..17)
             }
 
         // Original remains completely unchanged

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringTest.kt
@@ -20,11 +20,11 @@ class RichStringTest {
         val richString =
             RichString("12345678901234567890")
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
-                    setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 5..9)
-                    setAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 10..15)
-                    setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 10..15)
-                    setAttribute(BackgroundColorKey, RgbaColor(0xFFFF00FF), range = 16..19)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4)
+                    setSpanAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 5..9)
+                    setSpanAttribute(BackgroundColorKey, RgbaColor(0xFF00FF00), range = 10..15)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 10..15)
+                    setSpanAttribute(BackgroundColorKey, RgbaColor(0xFFFF00FF), range = 16..19)
                 }
 
         // There should be 4 internal spans: [0..4], [5..9], [10..15], [16..19]
@@ -50,9 +50,9 @@ class RichStringTest {
         val richString =
             RichString("01234567890123456789") // length 20
                 .edit {
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 2..4)
-                    setAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 8..10)
-                    setAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 15..19)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 2..4)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 8..10)
+                    setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 15..19)
                 }
 
         val colorRuns = richString.runs(TextColorKey)


### PR DESCRIPTION
## Overview
Separates the base `AttributeKey` into specific `SpanAttributeKey` and `ParagraphAttributeKey` types to strictly enforce boundary constraints at compile time.

## Implementation Details
- Added `SpanAttributeKey` and `ParagraphAttributeKey` as sub-interfaces of `AttributeKey`.
- Restricted `setAttribute` and `setParagraphAttribute` in `RichStringBuilder` and `AttributeEditScope` to strictly typed keys.
- Restricted `paragraphStyle` definition in `AttributeStyleResolver` to `ParagraphAttributeKey`.
- Updated all built-in keys to align with this safety constraint.
- Updated tests appropriately to avoid `BoldKey` parameter type mismatch in paragraph mutations.

**Note:** This is a breaking change for custom attribute keys and methods consuming them.