### PR TITLE
feat(richtext): add query APIs to AttributeContainer

### DIFF
--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
@@ -48,7 +48,7 @@ public class AttributeContainer private constructor(
      * Returns the set of attribute keys currently stored in this container.
      */
     public val keys: Set<AttributeKey<*>>
-        get() = attributes.keys
+        get() = attributes.keys.toSet()
 
     /**
      * Returns true if this container contains the specified [key].
@@ -57,11 +57,13 @@ public class AttributeContainer private constructor(
 
     /**
      * Returns true if this container contains all of the specified [keys].
+     * If no keys are specified, this returns true (vacuous truth).
      */
     public fun containsAll(vararg keys: AttributeKey<*>): Boolean = keys.all { containsKey(it) }
 
     /**
      * Returns true if this container contains any of the specified [keys].
+     * If no keys are specified, this returns false.
      */
     public fun containsAny(vararg keys: AttributeKey<*>): Boolean = keys.any { containsKey(it) }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
@@ -34,6 +34,38 @@ public class AttributeContainer private constructor(
     public fun isEmpty(): Boolean = attributes.isEmpty()
 
     /**
+     * Returns true if this container has at least one attribute.
+     */
+    public fun isNotEmpty(): Boolean = attributes.isNotEmpty()
+
+    /**
+     * Returns the number of attributes stored in this container.
+     */
+    public val size: Int
+        get() = attributes.size
+
+    /**
+     * Returns the set of attribute keys currently stored in this container.
+     */
+    public val keys: Set<AttributeKey<*>>
+        get() = attributes.keys
+
+    /**
+     * Returns true if this container contains the specified [key].
+     */
+    public fun containsKey(key: AttributeKey<*>): Boolean = attributes.containsKey(key)
+
+    /**
+     * Returns true if this container contains all of the specified [keys].
+     */
+    public fun containsAll(vararg keys: AttributeKey<*>): Boolean = keys.all { containsKey(it) }
+
+    /**
+     * Returns true if this container contains any of the specified [keys].
+     */
+    public fun containsAny(vararg keys: AttributeKey<*>): Boolean = keys.any { containsKey(it) }
+
+    /**
      * Returns a new [AttributeContainer] with the specified [key] mapped to the [value].
      */
     public fun <T> plus(

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeContainerTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeContainerTest.kt
@@ -127,4 +127,106 @@ class AttributeContainerTest {
         twoPairs.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
         twoPairs.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
     }
+
+    @Test
+    fun `containsKey returns true for a key that exists`() {
+        val container = attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))
+        container.containsKey(TextColorKey) shouldBe true
+    }
+
+    @Test
+    fun `containsKey returns false for a key that does not exist`() {
+        val container = attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))
+        container.containsKey(BoldKey) shouldBe false
+    }
+
+    @Test
+    fun `containsKey returns false on empty container`() {
+        val container = attributeContainerOf()
+        container.containsKey(TextColorKey) shouldBe false
+    }
+
+    @Test
+    fun `keys returns all stored attribute keys`() {
+        val container =
+            attributeContainerOf(
+                TextColorKey to RgbaColor(0xFFFF0000),
+                BoldKey to Unit,
+            )
+        container.keys shouldBe setOf(TextColorKey, BoldKey)
+    }
+
+    @Test
+    fun `keys returns empty set on empty container`() {
+        val container = attributeContainerOf()
+        container.keys shouldBe emptySet()
+    }
+
+    @Test
+    fun `size returns the number of stored attributes`() {
+        val container =
+            attributeContainerOf(
+                TextColorKey to RgbaColor(0xFFFF0000),
+                BoldKey to Unit,
+            )
+        container.size shouldBe 2
+    }
+
+    @Test
+    fun `size returns 0 on empty container`() {
+        val container = attributeContainerOf()
+        container.size shouldBe 0
+    }
+
+    @Test
+    fun `isNotEmpty returns true when container has attributes`() {
+        val container = attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))
+        container.isNotEmpty() shouldBe true
+    }
+
+    @Test
+    fun `isNotEmpty returns false on empty container`() {
+        val container = attributeContainerOf()
+        container.isNotEmpty() shouldBe false
+    }
+
+    @Test
+    fun `containsAll returns true when all specified keys exist`() {
+        val container =
+            attributeContainerOf(
+                TextColorKey to RgbaColor(0xFFFF0000),
+                BoldKey to Unit,
+            )
+        container.containsAll(TextColorKey, BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `containsAll returns false when some keys are missing`() {
+        val container = attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))
+        container.containsAll(TextColorKey, BoldKey) shouldBe false
+    }
+
+    @Test
+    fun `containsAll returns true for single existing key`() {
+        val container = attributeContainerOf(BoldKey to Unit)
+        container.containsAll(BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `containsAny returns true when at least one key exists`() {
+        val container = attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))
+        container.containsAny(TextColorKey, BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `containsAny returns false when none of the keys exist`() {
+        val container = attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))
+        container.containsAny(BoldKey, ItalicKey) shouldBe false
+    }
+
+    @Test
+    fun `containsAny returns false on empty container`() {
+        val container = attributeContainerOf()
+        container.containsAny(BoldKey) shouldBe false
+    }
 }

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeContainerTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeContainerTest.kt
@@ -229,4 +229,16 @@ class AttributeContainerTest {
         val container = attributeContainerOf()
         container.containsAny(BoldKey) shouldBe false
     }
+
+    @Test
+    fun `containsAll returns true when no keys are specified`() {
+        val container = attributeContainerOf()
+        container.containsAll() shouldBe true
+    }
+
+    @Test
+    fun `containsAny returns false when no keys are specified`() {
+        val container = attributeContainerOf()
+        container.containsAny() shouldBe false
+    }
 }


### PR DESCRIPTION
## Overview
Adds helpful query and introspection APIs to `AttributeContainer`. This allows for more intuitive and concise condition checks within the `runs(predicate)` closures, eliminating the need to compare `getOrNull(key)` results against `null`.

## Implementation Details
- Added the following APIs to `AttributeContainer`:
  - `isNotEmpty(): Boolean`
  - `size: Int`
  - `keys: Set<AttributeKey<*>>`
  - `containsKey(key: AttributeKey<*>): Boolean`
  - `containsAll(vararg keys: AttributeKey<*>): Boolean`
  - `containsAny(vararg keys: AttributeKey<*>): Boolean`
- Added comprehensive tests for all new APIs in `AttributeContainerTest.kt`.