### PR TITLE
feat(richtext): add batch edit APIs and rename builder to buffer

### DIFF
--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import dev.mkeeda.arranger.richtext.RichSpan
 import dev.mkeeda.arranger.richtext.RichString
-import dev.mkeeda.arranger.richtext.RichStringBuilder
+import dev.mkeeda.arranger.richtext.RichStringBuffer
 
 public class RichTextState(initialText: RichString) {
     internal val textFieldState = TextFieldState(initialText.text)
@@ -24,7 +24,7 @@ public class RichTextState(initialText: RichString) {
                 spans = spans,
             )
 
-    public fun edit(block: RichStringBuilder.() -> Unit) {
+    public fun edit(block: RichStringBuffer.() -> Unit) {
         spans = richString.edit(block).spans
     }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
@@ -4,7 +4,7 @@ package dev.mkeeda.arranger.richtext
  * A builder DSL for safely mutating multiple text attributes within a specific range.
  */
 public class AttributeEditScope internal constructor(
-    private val builder: RichStringBuilder,
+    private val buffer: RichStringBuffer,
     private val range: IntRange,
 ) {
     /**
@@ -16,9 +16,9 @@ public class AttributeEditScope internal constructor(
         value: T?,
     ) {
         if (value == null) {
-            builder.removeSpanAttribute(key, range)
+            buffer.removeSpanAttribute(key, range)
         } else {
-            builder.setSpanAttribute(key, value, range)
+            buffer.setSpanAttribute(key, value, range)
         }
     }
 
@@ -31,9 +31,9 @@ public class AttributeEditScope internal constructor(
         value: T?,
     ) {
         if (value == null) {
-            builder.removeParagraphAttribute(key, range)
+            buffer.removeParagraphAttribute(key, range)
         } else {
-            builder.setParagraphAttribute(key, value, range)
+            buffer.setParagraphAttribute(key, value, range)
         }
     }
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensions.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensions.kt
@@ -22,7 +22,7 @@ public fun CharSequence.rangesOf(
     sequence {
         var currentIndex = 0
         while (true) {
-            val startIndex = indexOf(target, startIndex = currentIndex, ignoreCase = ignoreCase)
+            val startIndex = this@rangesOf.indexOf(target, startIndex = currentIndex, ignoreCase = ignoreCase)
             if (startIndex == -1) break
 
             val endIndex = startIndex + target.length

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensions.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensions.kt
@@ -18,17 +18,18 @@ public fun CharSequence.rangeOf(substring: String): IntRange {
 public fun CharSequence.rangesOf(
     target: String,
     ignoreCase: Boolean = false,
-): Sequence<IntRange> = sequence {
-    var currentIndex = 0
-    while (true) {
-        val startIndex = indexOf(target, startIndex = currentIndex, ignoreCase = ignoreCase)
-        if (startIndex == -1) break
-        
-        val endIndex = startIndex + target.length
-        yield(startIndex until endIndex)
-        currentIndex = endIndex
+): Sequence<IntRange> =
+    sequence {
+        var currentIndex = 0
+        while (true) {
+            val startIndex = indexOf(target, startIndex = currentIndex, ignoreCase = ignoreCase)
+            if (startIndex == -1) break
+
+            val endIndex = startIndex + target.length
+            yield(startIndex until endIndex)
+            currentIndex = endIndex
+        }
     }
-}
 
 /**
  * Returns a lazily evaluated sequence of all occurrence ranges of the specified [regex] within this character sequence.

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensions.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensions.kt
@@ -11,3 +11,28 @@ public fun CharSequence.rangeOf(substring: String): IntRange {
     require(startIndex >= 0) { "Substring '$substring' not found in '$this'" }
     return startIndex until (startIndex + substring.length)
 }
+
+/**
+ * Returns a lazily evaluated sequence of all occurrence ranges of the specified [target] within this character sequence.
+ */
+public fun CharSequence.rangesOf(
+    target: String,
+    ignoreCase: Boolean = false,
+): Sequence<IntRange> = sequence {
+    var currentIndex = 0
+    while (true) {
+        val startIndex = indexOf(target, startIndex = currentIndex, ignoreCase = ignoreCase)
+        if (startIndex == -1) break
+        
+        val endIndex = startIndex + target.length
+        yield(startIndex until endIndex)
+        currentIndex = endIndex
+    }
+}
+
+/**
+ * Returns a lazily evaluated sequence of all occurrence ranges of the specified [regex] within this character sequence.
+ */
+public fun CharSequence.rangesOf(regex: Regex): Sequence<IntRange> {
+    return regex.findAll(this).map { it.range }
+}

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
@@ -82,12 +82,12 @@ public data class RichString(
         }
 
     /**
-     * Executes the given [block] on a [RichStringBuilder] scoped to this [RichString],
+     * Executes the given [block] on a [RichStringBuffer] scoped to this [RichString],
      * and returns a completely new [RichString] carrying the modifications.
      */
-    public fun edit(block: RichStringBuilder.() -> Unit): RichString {
-        val builder = RichStringBuilder(currentSpans = spans, text = text)
-        builder.block()
-        return builder.build(text = text)
+    public fun edit(block: RichStringBuffer.() -> Unit): RichString {
+        val buffer = RichStringBuffer(currentSpans = spans, text = text)
+        buffer.block()
+        return buffer.build(text = text)
     }
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
@@ -98,6 +98,31 @@ public class RichStringBuffer internal constructor(
         AttributeEditScope(this, range).editAction()
     }
 
+    /**
+     * Applies a set of attribute mutations to all specified [ranges] using a DSL builder.
+     */
+    public fun editAll(
+        ranges: Sequence<IntRange>,
+        editAction: AttributeEditScope.() -> Unit,
+    ) {
+        for (range in ranges) {
+            editAttributes(range, editAction)
+        }
+    }
+
+    /**
+     * Applies a set of attribute mutations to all specified [runs] using a DSL builder.
+     * The [editAction] receives each [RichRun] to allow conditional logic based on existing attributes.
+     */
+    public fun editAll(
+        runs: Sequence<RichRun<AttributeContainer>>,
+        editAction: AttributeEditScope.(RichRun<AttributeContainer>) -> Unit,
+    ) {
+        for (run in runs) {
+            AttributeEditScope(this, run.range).editAction(run)
+        }
+    }
+
     private fun checkRange(range: IntRange) {
         require(!range.isEmpty()) { "Range must not be empty: $range" }
         require(range.first >= 0) { "Range start must not be negative: ${range.first}" }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
@@ -113,6 +113,10 @@ public class RichStringBuffer internal constructor(
     /**
      * Applies a set of attribute mutations to all specified [runs] using a DSL builder.
      * The [editAction] receives each [RichRun] to allow conditional logic based on existing attributes.
+     *
+     * Note: The [runs] sequence is consumed lazily during iteration. It is expected to be derived
+     * from an immutable [RichString] (e.g., via [RichString.runs]), not from any mutable state
+     * within this buffer.
      */
     public fun editAll(
         runs: Sequence<RichRun<AttributeContainer>>,

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
@@ -1,11 +1,11 @@
 package dev.mkeeda.arranger.richtext
 
 /**
- * A builder class used to safely mutate the attributes of a [RichString] within an `edit` block.
+ * A buffer class used to safely mutate the attributes of a [RichString] within an `edit` block.
  * All mutations are accumulated internally and used to produce a completely new, immutable [RichString] instance
  * when the block completes.
  */
-public class RichStringBuilder internal constructor(
+public class RichStringBuffer internal constructor(
     private var currentSpans: List<RichSpan>,
     private val text: String,
 ) {

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
@@ -1,6 +1,7 @@
 package dev.mkeeda.arranger.richtext
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
@@ -59,18 +59,22 @@ class CharSequenceExtensionsTest {
 
     @Test
     fun `rangesOf is lazily evaluated`() {
-        val text = "foo bar foo baz foo"
-        var evaluationCount = 0
-        val sequence =
-            text.rangesOf("foo").map {
-                evaluationCount++
-                it
+        val throwingCharSequence =
+            object : CharSequence {
+                override val length: Int get() = throw RuntimeException("Evaluated!")
+
+                override fun get(index: Int): Char = throw RuntimeException("Evaluated!")
+
+                override fun subSequence(startIndex: Int, endIndex: Int): CharSequence = throw RuntimeException("Evaluated!")
             }
 
-        evaluationCount shouldBe 0 // Not evaluated yet
+        // Just calling rangesOf should not evaluate the sequence and thus not throw
+        val sequence = throwingCharSequence.rangesOf("foo")
 
-        sequence.first() shouldBe 0..2
-        evaluationCount shouldBe 1 // Evaluated only the first match
+        // It should throw when the sequence is actually consumed
+        shouldThrow<RuntimeException> {
+            sequence.first()
+        }
     }
 
     @Test

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
@@ -34,4 +34,58 @@ class CharSequenceExtensionsTest {
         text.rangeOf("r") shouldBe 1..1 // Finds the first occurrence
         text.rangeOf("ger") shouldBe 5..7
     }
+
+    @Test
+    fun `rangesOf returns all matching ranges for a repeated word`() {
+        val text = "foo bar foo baz foo"
+        val ranges = text.rangesOf("foo").toList()
+        ranges shouldBe listOf(0..2, 8..10, 16..18)
+    }
+
+    @Test
+    fun `rangesOf with ignoreCase matches case-insensitively`() {
+        val text = "Hello hello HELLO"
+        val ranges = text.rangesOf("hello", ignoreCase = true).toList()
+        ranges shouldBe listOf(0..4, 6..10, 12..16)
+    }
+
+    @Test
+    fun `rangesOf returns empty sequence when no match found`() {
+        val text = "Hello Kotlin World"
+        val ranges = text.rangesOf("Java").toList()
+        ranges.shouldBeEmpty()
+    }
+
+    @Test
+    fun `rangesOf is lazily evaluated`() {
+        val text = "foo bar foo baz foo"
+        var evaluationCount = 0
+        val sequence = text.rangesOf("foo").map {
+            evaluationCount++
+            it
+        }
+
+        evaluationCount shouldBe 0 // Not evaluated yet
+
+        sequence.first() shouldBe 0..2
+        evaluationCount shouldBe 1 // Evaluated only the first match
+    }
+
+    @Test
+    fun `rangesOf with regex returns all matching ranges`() {
+        val text = "#kotlin is great #android #compose"
+        val regex = Regex("#\\w+")
+        val ranges = text.rangesOf(regex).toList()
+
+        ranges shouldBe listOf(0..6, 17..24, 26..33)
+    }
+
+    @Test
+    fun `rangesOf with regex returns empty sequence when no match`() {
+        val text = "hello world"
+        val regex = Regex("#\\w+")
+        val ranges = text.rangesOf(regex).toList()
+
+        ranges.shouldBeEmpty()
+    }
 }

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/CharSequenceExtensionsTest.kt
@@ -61,10 +61,11 @@ class CharSequenceExtensionsTest {
     fun `rangesOf is lazily evaluated`() {
         val text = "foo bar foo baz foo"
         var evaluationCount = 0
-        val sequence = text.rangesOf("foo").map {
-            evaluationCount++
-            it
-        }
+        val sequence =
+            text.rangesOf("foo").map {
+                evaluationCount++
+                it
+            }
 
         evaluationCount shouldBe 0 // Not evaluated yet
 

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
@@ -8,17 +8,19 @@ class RichStringBatchEditTest {
     @Test
     fun `editAll applies attributes to all specified ranges`() {
         val original = RichString("12345678901234567890")
-        
-        val ranges = sequenceOf(
-            0..4,
-            10..14
-        )
 
-        val edited = original.edit {
-            editAll(ranges) {
-                textColor(RgbaColor(0xFFFF0000))
+        val ranges =
+            sequenceOf(
+                0..4,
+                10..14,
+            )
+
+        val edited =
+            original.edit {
+                editAll(ranges) {
+                    textColor(RgbaColor(0xFFFF0000))
+                }
             }
-        }
 
         val spans = edited.spans
         spans shouldHaveSize 2
@@ -31,12 +33,13 @@ class RichStringBatchEditTest {
     @Test
     fun `editAll with empty ranges is a no-op`() {
         val original = RichString("1234567890")
-        
-        val edited = original.edit {
-            editAll(emptySequence<IntRange>()) {
-                textColor(RgbaColor(0xFFFF0000))
+
+        val edited =
+            original.edit {
+                editAll(emptySequence<IntRange>()) {
+                    textColor(RgbaColor(0xFFFF0000))
+                }
             }
-        }
 
         edited.spans.isEmpty() shouldBe true
         edited.text shouldBe original.text
@@ -44,37 +47,39 @@ class RichStringBatchEditTest {
 
     @Test
     fun `editAll with runs applies attributes based on original run values`() {
-        val original = RichString("01234567890123456789").edit {
-            // Setup original runs
-            setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4) // Red
-            setSpanAttribute(TextColorKey, RgbaColor(0xFF00FF00), range = 5..9) // Green
-            setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 10..14) // Red
-        }
+        val original =
+            RichString("01234567890123456789").edit {
+                // Setup original runs
+                setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4) // Red
+                setSpanAttribute(TextColorKey, RgbaColor(0xFF00FF00), range = 5..9) // Green
+                setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 10..14) // Red
+            }
 
         // Query runs that are red
         val redRuns = original.runs { it.getOrNull(TextColorKey) == RgbaColor(0xFFFF0000) }
 
         // Change red runs to blue
-        val edited = original.edit {
-            editAll(redRuns) { run ->
-                // Ensure run has the expected original value
-                run.value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-                // Overwrite with Blue
-                textColor(RgbaColor(0xFF0000FF))
+        val edited =
+            original.edit {
+                editAll(redRuns) { run ->
+                    // Ensure run has the expected original value
+                    run.value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+                    // Overwrite with Blue
+                    textColor(RgbaColor(0xFF0000FF))
+                }
             }
-        }
 
         val spans = edited.spans
         spans shouldHaveSize 3
-        
+
         // 0..4 is now blue
         spans[0].range shouldBe 0..4
         spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
-        
+
         // 5..9 remains green
         spans[1].range shouldBe 5..9
         spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF00FF00)
-        
+
         // 10..14 is now blue
         spans[2].range shouldBe 10..14
         spans[2].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
@@ -83,24 +88,25 @@ class RichStringBatchEditTest {
     @Test
     fun `editAll combined with rangesOf highlights all keyword occurrences`() {
         val original = RichString("Error: Invalid input. Error: Null pointer. Error: Timeout.")
-        
+
         // Search
         val errorRanges = original.text.rangesOf("Error:")
-        
+
         // Batch edit
-        val edited = original.edit {
-            editAll(errorRanges) {
-                textColor(RgbaColor(0xFFFF0000)) // Highlight in red
-                bold()
+        val edited =
+            original.edit {
+                editAll(errorRanges) {
+                    textColor(RgbaColor(0xFFFF0000)) // Highlight in red
+                    bold()
+                }
             }
-        }
 
         val spans = edited.spans
         spans shouldHaveSize 3
-        
+
         // "Error:" spans should be highlighted
         val expectedRanges = listOf(0..5, 22..27, 43..48)
-        
+
         for (i in 0..2) {
             spans[i].range shouldBe expectedRanges[i]
             spans[i].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
@@ -1,0 +1,110 @@
+package dev.mkeeda.arranger.richtext
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class RichStringBatchEditTest {
+    @Test
+    fun `editAll applies attributes to all specified ranges`() {
+        val original = RichString("12345678901234567890")
+        
+        val ranges = sequenceOf(
+            0..4,
+            10..14
+        )
+
+        val edited = original.edit {
+            editAll(ranges) {
+                textColor(RgbaColor(0xFFFF0000))
+            }
+        }
+
+        val spans = edited.spans
+        spans shouldHaveSize 2
+        spans[0].range shouldBe 0..4
+        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        spans[1].range shouldBe 10..14
+        spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+    }
+
+    @Test
+    fun `editAll with empty ranges is a no-op`() {
+        val original = RichString("1234567890")
+        
+        val edited = original.edit {
+            editAll(emptySequence<IntRange>()) {
+                textColor(RgbaColor(0xFFFF0000))
+            }
+        }
+
+        edited.spans.isEmpty() shouldBe true
+        edited.text shouldBe original.text
+    }
+
+    @Test
+    fun `editAll with runs applies attributes based on original run values`() {
+        val original = RichString("01234567890123456789").edit {
+            // Setup original runs
+            setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 0..4) // Red
+            setSpanAttribute(TextColorKey, RgbaColor(0xFF00FF00), range = 5..9) // Green
+            setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 10..14) // Red
+        }
+
+        // Query runs that are red
+        val redRuns = original.runs { it.getOrNull(TextColorKey) == RgbaColor(0xFFFF0000) }
+
+        // Change red runs to blue
+        val edited = original.edit {
+            editAll(redRuns) { run ->
+                // Ensure run has the expected original value
+                run.value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+                // Overwrite with Blue
+                textColor(RgbaColor(0xFF0000FF))
+            }
+        }
+
+        val spans = edited.spans
+        spans shouldHaveSize 3
+        
+        // 0..4 is now blue
+        spans[0].range shouldBe 0..4
+        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
+        
+        // 5..9 remains green
+        spans[1].range shouldBe 5..9
+        spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF00FF00)
+        
+        // 10..14 is now blue
+        spans[2].range shouldBe 10..14
+        spans[2].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
+    }
+
+    @Test
+    fun `editAll combined with rangesOf highlights all keyword occurrences`() {
+        val original = RichString("Error: Invalid input. Error: Null pointer. Error: Timeout.")
+        
+        // Search
+        val errorRanges = original.text.rangesOf("Error:")
+        
+        // Batch edit
+        val edited = original.edit {
+            editAll(errorRanges) {
+                textColor(RgbaColor(0xFFFF0000)) // Highlight in red
+                bold()
+            }
+        }
+
+        val spans = edited.spans
+        spans shouldHaveSize 3
+        
+        // "Error:" spans should be highlighted
+        val expectedRanges = listOf(0..5, 22..27, 43..48)
+        
+        for (i in 0..2) {
+            spans[i].range shouldBe expectedRanges[i]
+            spans[i].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+            spans[i].attributes.getOrNull(BoldKey) shouldBe Unit
+        }
+    }
+}

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
@@ -1,6 +1,5 @@
 package dev.mkeeda.arranger.richtext
 
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 
@@ -23,11 +22,11 @@ class RichStringBatchEditTest {
             }
 
         val spans = edited.spans
-        spans shouldHaveSize 2
-        spans[0].range shouldBe 0..4
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[1].range shouldBe 10..14
-        spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        spans shouldBe
+            listOf(
+                RichSpan(0..4, attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))),
+                RichSpan(10..14, attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000))),
+            )
     }
 
     @Test
@@ -70,19 +69,12 @@ class RichStringBatchEditTest {
             }
 
         val spans = edited.spans
-        spans shouldHaveSize 3
-
-        // 0..4 is now blue
-        spans[0].range shouldBe 0..4
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
-
-        // 5..9 remains green
-        spans[1].range shouldBe 5..9
-        spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF00FF00)
-
-        // 10..14 is now blue
-        spans[2].range shouldBe 10..14
-        spans[2].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
+        spans shouldBe
+            listOf(
+                RichSpan(0..4, attributeContainerOf(TextColorKey to RgbaColor(0xFF0000FF))),
+                RichSpan(5..9, attributeContainerOf(TextColorKey to RgbaColor(0xFF00FF00))),
+                RichSpan(10..14, attributeContainerOf(TextColorKey to RgbaColor(0xFF0000FF))),
+            )
     }
 
     @Test
@@ -102,15 +94,11 @@ class RichStringBatchEditTest {
             }
 
         val spans = edited.spans
-        spans shouldHaveSize 3
-
-        // "Error:" spans should be highlighted
-        val expectedRanges = listOf(0..5, 22..27, 43..48)
-
-        for (i in 0..2) {
-            spans[i].range shouldBe expectedRanges[i]
-            spans[i].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-            spans[i].attributes.getOrNull(BoldKey) shouldBe Unit
-        }
+        spans shouldBe
+            listOf(
+                RichSpan(0..5, attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000), BoldKey to Unit)),
+                RichSpan(22..27, attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000), BoldKey to Unit)),
+                RichSpan(43..48, attributeContainerOf(TextColorKey to RgbaColor(0xFFFF0000), BoldKey to Unit)),
+            )
     }
 }

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
@@ -1,5 +1,6 @@
 package dev.mkeeda.arranger.richtext
 
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 
@@ -40,7 +41,7 @@ class RichStringBatchEditTest {
                 }
             }
 
-        edited.spans.isEmpty() shouldBe true
+        edited.spans.shouldBeEmpty()
         edited.text shouldBe original.text
     }
 


### PR DESCRIPTION
## Overview
This pull request introduces declarative batch editing APIs for `RichString` and renames `RichStringBuilder` to `RichStringBuffer` to better reflect its role as a mutation buffer, aligning with Compose's `TextFieldBuffer` pattern.

## Implementation Details
1. **Rename to `RichStringBuffer`**:
   - Renamed `RichStringBuilder` to `RichStringBuffer` to clarify its role as a stateful buffer during `edit {}` blocks.
   - Updated all references across `richtext` and `richtext-editor` modules.

2. **Search APIs (`CharSequence.rangesOf`)**:
   - Added `rangesOf(target: String, ignoreCase: Boolean = false)` to find all occurrences of a specific string and return them as a lazy `Sequence<IntRange>`.
   - Added `rangesOf(regex: Regex)` to find all occurrences matching a regex as a lazy `Sequence<IntRange>`.

3. **Batch Edit APIs (`RichStringBuffer.editAll`)**:
   - Added `editAll(ranges: Sequence<IntRange>, action)` to apply attribute mutations efficiently across multiple ranges.
   - Added `editAll(runs: Sequence<RichRun<AttributeContainer>>, action)` to conditionally mutate attributes based on their existing values.