### PR TITLE
fix(richtext): correct paragraph span alignment during text editing

### DIFF
--- a/build-logic/convention/src/main/kotlin/dev/mkeeda/arranger/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/dev/mkeeda/arranger/buildlogic/KotlinAndroid.kt
@@ -35,6 +35,7 @@ private fun Project.configureKotlin() {
             freeCompilerArgs.addAll(
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                "-opt-in=dev.mkeeda.arranger.richtext.InternalArrangerApi",
             )
         }
     }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.TextRange
 import dev.mkeeda.arranger.richtext.RichSpan
 import dev.mkeeda.arranger.richtext.RichString
 import dev.mkeeda.arranger.richtext.RichStringBuffer
+import dev.mkeeda.arranger.richtext.resnapParagraphSpans
 
 @Stable
 public class RichTextState(initialText: RichString) {
@@ -46,7 +47,7 @@ public class RichTextState(initialText: RichString) {
     internal fun updateRichString(buffer: TextFieldBuffer) {
         if (buffer.changes.changeCount == 0) return
 
-        this.spans =
+        val shiftedSpans =
             (0 until buffer.changes.changeCount).fold(spans) { currentSpans, i ->
                 val originalRange = buffer.changes.getOriginalRange(i)
                 val range = buffer.changes.getRange(i)
@@ -65,6 +66,8 @@ public class RichTextState(initialText: RichString) {
                     )
                 }
             }
+
+        this.spans = shiftedSpans.resnapParagraphSpans(buffer.toString())
     }
 
     private fun shiftSpan(

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -3,6 +3,7 @@ package dev.mkeeda.arranger.richtext.editor
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.delete
 import androidx.compose.foundation.text.input.insert
+import dev.mkeeda.arranger.richtext.BlockquoteKey
 import dev.mkeeda.arranger.richtext.BoldKey
 import dev.mkeeda.arranger.richtext.RichString
 import dev.mkeeda.arranger.richtext.rangeOf
@@ -159,6 +160,125 @@ class RichTextStateTest {
 
         val spans = state.richString.spans
         spans.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `deleting a line break snaps the paragraph span to the new paragraph boundaries`() {
+        val initialText = "Alpha\nBravo\nCharlie"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setParagraphAttribute(BlockquoteKey, Unit, range = initialText.rangeOf("Bravo"))
+                    },
+            )
+
+        // Initial span should be "Bravo\n" (indices 6..11)
+        state.richString.spans.first().range shouldBe (6..11)
+
+        state.simulateTextEdit {
+            // Delete the '\n' between Alpha and Bravo
+            deleteSubstring("pha\nBr")
+            insert(originalText.indexOf("pha\nBr"), "phaBr")
+        }
+
+        val expectedText = "AlphaBravo\nCharlie"
+        state.richString.text shouldBe expectedText
+
+        val spans = state.richString.spans
+        spans.size shouldBe 1
+        // Expected span is the new first paragraph: "AlphaBravo\n" (indices 0..10)
+        spans.first().range shouldBe (0..10)
+    }
+
+    @Test
+    fun `inserting a line break inside a paragraph span expands the span to cover both new paragraphs`() {
+        val initialText = "Alpha\nBravo"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setParagraphAttribute(BlockquoteKey, Unit, range = initialText.rangeOf("Bravo"))
+                    },
+            )
+
+        // Initial span should be "Bravo" (indices 6..10)
+        state.richString.spans.first().range shouldBe (6..10)
+
+        state.simulateTextEdit {
+            // Insert a '\n' in the middle of Bravo
+            insertAfter(substring = "Bra", textToInsert = "\n")
+        }
+
+        val expectedText = "Alpha\nBra\nvo"
+        state.richString.text shouldBe expectedText
+
+        val spans = state.richString.spans
+        spans.size shouldBe 1
+        // Expected span is the combined new paragraphs: "Bra\nvo" (indices 6..11)
+        spans.first().range shouldBe (6..11)
+    }
+
+    @Test
+    fun `deleting text inside a paragraph span maintains the span boundaries`() {
+        val initialText = "Alpha\nBravo\nCharlie"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setParagraphAttribute(BlockquoteKey, Unit, range = initialText.rangeOf("Bravo"))
+                    },
+            )
+
+        state.simulateTextEdit {
+            deleteSubstring("av")
+        }
+
+        val expectedText = "Alpha\nBro\nCharlie"
+        state.richString.text shouldBe expectedText
+
+        val spans = state.richString.spans
+        spans.size shouldBe 1
+        // Expected span is "Bro\n" (indices 6..9)
+        spans.first().range shouldBe (6..9)
+    }
+
+    @Test
+    fun `span attribute is unaffected by paragraph re-snapping`() {
+        val initialText = "Alpha\nBravo"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("Bravo"))
+                        setParagraphAttribute(BlockquoteKey, Unit, range = initialText.rangeOf("Bravo"))
+                    },
+            )
+
+        state.simulateTextEdit {
+            // Delete the '\n' between Alpha and Bravo
+            // Instead of overlapping Bravo, we delete just '\n' and insert a space
+            delete(5, 6)
+            insert(5, " ")
+        }
+
+        val expectedText = "Alpha Bravo"
+        state.richString.text shouldBe expectedText
+
+        val spans = state.richString.spans
+        spans.size shouldBe 2
+
+        // Due to SpanMerger, the spans are tessellated chunks.
+        val firstSpan = spans[0]
+        val secondSpan = spans[1]
+
+        firstSpan.range shouldBe (0..5)
+        firstSpan.attributes.containsKey(BlockquoteKey) shouldBe true
+        firstSpan.attributes.containsKey(BoldKey) shouldBe false
+
+        secondSpan.range shouldBe (6..10)
+        secondSpan.attributes.containsKey(BlockquoteKey) shouldBe true
+        secondSpan.attributes.containsKey(BoldKey) shouldBe true
     }
 }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
@@ -68,12 +68,6 @@ public class AttributeContainer private constructor(
     public fun containsAny(vararg keys: AttributeKey<*>): Boolean = keys.any { containsKey(it) }
 
     /**
-     * Returns true if this container contains any [ParagraphAttributeKey].
-     */
-    public fun hasParagraphAttributes(): Boolean =
-        attributes.keys.any { it is ParagraphAttributeKey<*> }
-
-    /**
      * Returns a new [AttributeContainer] containing only the paragraph attributes.
      */
     internal fun filterParagraphAttributes(): AttributeContainer {

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
@@ -68,6 +68,26 @@ public class AttributeContainer private constructor(
     public fun containsAny(vararg keys: AttributeKey<*>): Boolean = keys.any { containsKey(it) }
 
     /**
+     * Returns true if this container contains any [ParagraphAttributeKey].
+     */
+    public fun hasParagraphAttributes(): Boolean =
+        attributes.keys.any { it is ParagraphAttributeKey<*> }
+
+    /**
+     * Returns a new [AttributeContainer] containing only the paragraph attributes.
+     */
+    internal fun filterParagraphAttributes(): AttributeContainer {
+        return AttributeContainer(attributes = attributes.filterKeys { it is ParagraphAttributeKey<*> })
+    }
+
+    /**
+     * Returns a new [AttributeContainer] containing only the non-paragraph (span) attributes.
+     */
+    internal fun filterSpanAttributes(): AttributeContainer {
+        return AttributeContainer(attributes = attributes.filterKeys { it !is ParagraphAttributeKey<*> })
+    }
+
+    /**
      * Returns a new [AttributeContainer] with the specified [key] mapped to the [value].
      */
     public fun <T> plus(

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/InternalArrangerApi.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/InternalArrangerApi.kt
@@ -1,0 +1,9 @@
+package dev.mkeeda.arranger.richtext
+
+@RequiresOptIn(
+    message = "This API is internal to Arranger and should not be used outside of it.",
+    level = RequiresOptIn.Level.ERROR,
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+public annotation class InternalArrangerApi

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnapping.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnapping.kt
@@ -25,18 +25,8 @@ internal fun IntRange.snapToParagraphs(text: String): IntRange {
  */
 public fun List<RichSpan>.resnapParagraphSpans(text: String): List<RichSpan> {
     if (this.isEmpty()) return this
-    if (text.isEmpty()) {
-        return mapNotNull { span ->
-            val sAttrs = span.attributes.filterSpanAttributes()
-            if (sAttrs.isNotEmpty()) {
-                span.copy(attributes = sAttrs)
-            } else {
-                null
-            }
-        }
-    }
 
-    var resultSpans =
+    val spanOnlySpans =
         mapNotNull { span ->
             val sAttrs = span.attributes.filterSpanAttributes()
             if (sAttrs.isNotEmpty()) {
@@ -45,6 +35,10 @@ public fun List<RichSpan>.resnapParagraphSpans(text: String): List<RichSpan> {
                 null
             }
         }
+
+    if (text.isEmpty()) return spanOnlySpans
+
+    var resultSpans = spanOnlySpans
 
     val pSpans =
         this.mapNotNull { span ->

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnapping.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnapping.kt
@@ -1,0 +1,72 @@
+package dev.mkeeda.arranger.richtext
+
+/**
+ * Expands this range to cover the entire paragraph(s) it intersects with
+ * in the given [text]. Paragraphs are delimited by '\n'.
+ */
+internal fun IntRange.snapToParagraphs(text: String): IntRange {
+    val start =
+        text.lastIndexOf('\n', startIndex = this.first - 1).let {
+            if (it == -1) 0 else it + 1
+        }
+    val end =
+        text.indexOf('\n', startIndex = this.last).let {
+            if (it == -1) text.lastIndex else it
+        }
+    return start..end
+}
+
+/**
+ * Re-snaps any spans containing [ParagraphAttributeKey]s to align with
+ * paragraph boundaries in the given [text].
+ *
+ * Spans that contain only [SpanAttributeKey]s are left unchanged.
+ * Paragraph spans whose range becomes invalid (e.g., in empty text) are removed.
+ */
+public fun List<RichSpan>.resnapParagraphSpans(text: String): List<RichSpan> {
+    if (this.isEmpty()) return this
+    if (text.isEmpty()) {
+        return mapNotNull { span ->
+            val sAttrs = span.attributes.filterSpanAttributes()
+            if (sAttrs.isNotEmpty()) {
+                span.copy(attributes = sAttrs)
+            } else {
+                null
+            }
+        }
+    }
+
+    var resultSpans =
+        mapNotNull { span ->
+            val sAttrs = span.attributes.filterSpanAttributes()
+            if (sAttrs.isNotEmpty()) {
+                span.copy(attributes = sAttrs)
+            } else {
+                null
+            }
+        }
+
+    val pSpans =
+        this.mapNotNull { span ->
+            val pAttrs = span.attributes.filterParagraphAttributes()
+            if (pAttrs.isNotEmpty()) {
+                RichSpan(range = span.range, attributes = pAttrs)
+            } else {
+                null
+            }
+        }
+
+    for (pSpan in pSpans) {
+        val clampedFirst = pSpan.range.first.coerceIn(0, text.lastIndex)
+        val clampedLast = pSpan.range.last.coerceIn(0, text.lastIndex)
+        if (clampedFirst <= clampedLast) {
+            val snappedRange = (clampedFirst..clampedLast).snapToParagraphs(text)
+            resultSpans =
+                resultSpans.transformSpans(snappedRange) { attrs ->
+                    attrs + pSpan.attributes
+                }
+        }
+    }
+
+    return resultSpans
+}

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnapping.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnapping.kt
@@ -23,6 +23,7 @@ internal fun IntRange.snapToParagraphs(text: String): IntRange {
  * Spans that contain only [SpanAttributeKey]s are left unchanged.
  * Paragraph spans whose range becomes invalid (e.g., in empty text) are removed.
  */
+@InternalArrangerApi
 public fun List<RichSpan>.resnapParagraphSpans(text: String): List<RichSpan> {
     if (this.isEmpty()) return this
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringBuffer.kt
@@ -59,18 +59,6 @@ public class RichStringBuffer internal constructor(
             }
     }
 
-    private fun IntRange.snapToParagraphs(text: String): IntRange {
-        val start =
-            text.lastIndexOf('\n', startIndex = this.first - 1).let {
-                if (it == -1) 0 else it + 1
-            }
-        val end =
-            text.indexOf('\n', startIndex = this.last).let {
-                if (it == -1) text.lastIndex else it
-            }
-        return start..end
-    }
-
     /**
      * Removes any paragraph attributes associated with the specified [key] within the given [range].
      * The [range] is automatically expanded to span the entire paragraphs (separated by `\n`)

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnappingTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/ParagraphSnappingTest.kt
@@ -1,0 +1,84 @@
+package dev.mkeeda.arranger.richtext
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class ParagraphSnappingTest {
+    @Test
+    fun `snapToParagraphs expands range to paragraph boundaries`() {
+        val text = "Line1\nLine2\nLine3"
+
+        // Index 8 is 'n' in "Line2". Should snap to "Line2\n" (6..11)
+        (8..8).snapToParagraphs(text) shouldBe (6..11)
+
+        // Index 0 is 'L' in "Line1". Should snap to "Line1\n" (0..5)
+        (0..0).snapToParagraphs(text) shouldBe (0..5)
+
+        // Last index is in "Line3". Should snap to "Line3" (12..16)
+        (text.lastIndex..text.lastIndex).snapToParagraphs(text) shouldBe (12..16)
+
+        // Spanning across paragraphs (from 'n' in Line1 to 'L' in Line3)
+        (2..12).snapToParagraphs(text) shouldBe (0..16)
+    }
+
+    @Test
+    fun `resnapParagraphSpans adjusts ranges of spans with ParagraphAttributeKey`() {
+        val text = "Line1\nLine2\nLine3"
+
+        val attributes = attributeContainerOf(BlockquoteKey to Unit)
+        // Simulate a shifted span that doesn't align with paragraph boundaries
+        // E.g. (8..10) which is inside "Line2"
+        val shiftedSpan = RichSpan(range = 8..10, attributes = attributes)
+
+        val resnappedSpans = listOf(shiftedSpan).resnapParagraphSpans(text)
+
+        resnappedSpans shouldHaveSize 1
+        // It should expand to the full paragraph "Line2\n"
+        resnappedSpans.first().range shouldBe (6..11)
+    }
+
+    @Test
+    fun `resnapParagraphSpans ignores spans with only SpanAttributeKey`() {
+        val text = "Line1\nLine2\nLine3"
+
+        val attributes = attributeContainerOf(BoldKey to Unit)
+        // A span applied only to the word "Line2"
+        val span = RichSpan(range = 6..10, attributes = attributes)
+
+        val resnappedSpans = listOf(span).resnapParagraphSpans(text)
+
+        resnappedSpans shouldHaveSize 1
+        // Range should remain unchanged
+        resnappedSpans.first().range shouldBe (6..10)
+    }
+
+    @Test
+    fun `resnapParagraphSpans removes paragraph spans when text is empty`() {
+        val text = ""
+
+        val paragraphSpan = RichSpan(range = 0..5, attributes = attributeContainerOf(BlockquoteKey to Unit))
+        val textSpan = RichSpan(range = 0..5, attributes = attributeContainerOf(BoldKey to Unit))
+
+        val resnappedSpans = listOf(paragraphSpan, textSpan).resnapParagraphSpans(text)
+
+        resnappedSpans shouldHaveSize 1
+        // Only the SpanAttributeKey span should remain
+        resnappedSpans.first().attributes.containsKey(BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `resnapParagraphSpans clamps out of bounds ranges before snapping`() {
+        val text = "Line1"
+
+        val attributes = attributeContainerOf(BlockquoteKey to Unit)
+        // A span whose range exceeds the text length
+        val outOfBoundsSpan = RichSpan(range = 0..100, attributes = attributes)
+
+        val resnappedSpans = listOf(outOfBoundsSpan).resnapParagraphSpans(text)
+
+        resnappedSpans shouldHaveSize 1
+        // Range should be clamped to valid text length
+        resnappedSpans.first().range shouldBe (0..4)
+    }
+}


### PR DESCRIPTION
## Overview
This PR resolves a critical bug where `ParagraphStyle` attributes (such as `BlockquoteKey`) would become misaligned or completely disappear when users performed text editing operations (e.g., character deletion, newline insertion) that overlapped with the styled paragraph boundaries.

## Implementation Details
- **Refactoring & Extraction**: Extracted the paragraph snapping logic from `RichStringBuffer` into a shared `ParagraphSnapping.kt` file.
- **Attribute Separation**: Added `filterParagraphAttributes()` and `filterSpanAttributes()` to `AttributeContainer` to correctly decouple block-level styling from inline styling (e.g., `BoldKey`).
- **Resnap Algorithm**: Implemented `resnapParagraphSpans()`, which separates paragraph and span attributes, calculates the newly snapped paragraph bounds, and safely merges them back together using the `transformSpans` (Sweep-line chunking) algorithm. This prevents overlapping span drops.
- **Integration**: `RichTextState.updateRichString()` now invokes `resnapParagraphSpans` to preserve paragraph boundaries continuously during edits.
- **Testing**: Added rigorous edge-case unit tests in `RichTextStateTest` for deletions, newline insertions, and span attribute preservation under re-snapping conditions.