### PR TITLE
chore: setup Maven Central publishing pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v6
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_IN_MEMORY_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,3 +30,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_IN_MEMORY_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signAllPublications: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Arranger
+
+Thank you for your interest in contributing to Arranger! This document outlines our development process, versioning strategy, and release workflow.
+
+## Versioning Strategy (0.x.x Phase)
+
+Arranger follows [Semantic Versioning](https://semver.org/), but while we are in the `0.x.x` pre-v1.0 phase, we apply the following specific rules to set clear expectations:
+
+* **Minor Version (`0.X.0`)**: Incremented when we enter a new development phase (milestone) or introduce significant architectural/breaking changes.
+* **Patch Version (`0.x.Y`)**: Generally not used during the pre-release phase. We rely on pre-release suffixes instead.
+* **Pre-release Suffix (`-alphaXX`, `-betaXX`)**: Incremented for smaller features, bug fixes, or minor API tweaks within the same milestone (e.g., `0.1.0-alpha01` -> `0.1.0-alpha02`).
+    * `-alpha`: Features are still incomplete or APIs are subject to rapid change.
+    * `-beta`: The feature set for the milestone is mostly complete, focusing on stabilization and bug fixes.
+
+*Note: The single source of truth for the project's current version is the `VERSION_NAME` property in the root `gradle.properties` file.*
+
+## Release Process (GitHub Releases Driven)
+
+We use an automated CI/CD pipeline triggered by GitHub Releases. If you are a maintainer, follow these steps to publish a new version:
+
+1.  **Update Version**: Update the `VERSION_NAME` in `gradle.properties` (e.g., to `0.1.0-alpha01`) and merge it into the `main` branch.
+2.  **Draft Release**: Go to GitHub Releases and click "Draft a new release".
+3.  **Create Tag**: Create a new tag matching the version with a `v` prefix (e.g., `v0.1.0-alpha01`).
+4.  **Generate Notes**: Use the "Generate release notes" button to auto-generate the changelog based on merged PRs.
+5.  **Publish**: Click "Publish release". The GitHub Actions workflow will automatically build, sign, and publish the artifacts to Maven Central.
+
+## Commit Guidelines
+
+This project strictly follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. Please ensure your commit messages and PR titles adhere to this format (e.g., `feat(editor): add text insertion API`, `fix(core): resolve span calculation overlap`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,17 @@ Arranger follows [Semantic Versioning](https://semver.org/), but while we are in
 
 *Note: The single source of truth for the project's current version is the `VERSION_NAME` property in the root `gradle.properties` file.*
 
-## Release Process (GitHub Releases Driven)
+## Release Process (Tag-Driven)
 
-We use an automated CI/CD pipeline triggered by GitHub Releases. If you are a maintainer, follow these steps to publish a new version:
+We use an automated CI/CD pipeline triggered by a tag push matching `v*`. If you are a maintainer, follow these steps to publish a new version:
 
 1.  **Update Version**: Update the `VERSION_NAME` in `gradle.properties` (e.g., to `0.1.0-alpha01`) and merge it into the `main` branch.
 2.  **Draft Release**: Go to GitHub Releases and click "Draft a new release".
 3.  **Create Tag**: Create a new tag matching the version with a `v` prefix (e.g., `v0.1.0-alpha01`).
 4.  **Generate Notes**: Use the "Generate release notes" button to auto-generate the changelog based on merged PRs.
-5.  **Publish**: Click "Publish release". The GitHub Actions workflow will automatically build, sign, and publish the artifacts to Maven Central.
+5.  **Publish**: Click "Publish release". GitHub will push the associated tag, which automatically triggers the GitHub Actions workflow to build, sign, and publish the artifacts to Maven Central.
+
+*Note: Because the workflow listens to tag pushes, pushing a `v*` tag directly via git (without creating a GitHub Release) will also trigger the publish workflow. Please be careful when managing tags locally.*
 
 ## Commit Guidelines
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.spotless.gradlePlugin)
+    compileOnly(libs.vanniktech.maven.publish.gradlePlugin)
 }
 
 gradlePlugin {
@@ -28,6 +29,10 @@ gradlePlugin {
         register("androidSpotless") {
             id = "arranger.android.spotless"
             implementationClass = "AndroidSpotlessConventionPlugin"
+        }
+        register("mavenPublish") {
+            id = "arranger.maven.publish"
+            implementationClass = "MavenPublishConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.spotless.gradlePlugin)
-    compileOnly(libs.vanniktech.maven.publish.gradlePlugin)
+    implementation(libs.vanniktech.maven.publish.gradlePlugin)
 }
 
 gradlePlugin {

--- a/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
@@ -1,5 +1,6 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -9,8 +10,8 @@ class MavenPublishConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.apply("com.vanniktech.maven.publish")
             extensions.configure<MavenPublishBaseExtension> {
-                publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-                signAllPublications()
+                publishToMavenCentral()
+                configure(AndroidSingleVariantLibrary(javadocJar = JavadocJar.None()))
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
@@ -11,6 +11,12 @@ class MavenPublishConventionPlugin : Plugin<Project> {
             pluginManager.apply("com.vanniktech.maven.publish")
             extensions.configure<MavenPublishBaseExtension> {
                 publishToMavenCentral()
+                // Dokka (K1 engine) fails to resolve opt-in annotation markers (e.g., @InternalArrangerApi)
+                // used in richtext-editor, causing the javadoc generation task to crash.
+                // JavadocJar.None() skips javadoc jar generation, which is acceptable because:
+                //   - Maven Central (Central Portal) does not require a javadoc jar.
+                //   - IDE quick-docs work fine via the sources jar.
+                // TODO: Re-enable javadoc generation once migrating to Dokka K2 engine.
                 configure(AndroidSingleVariantLibrary(javadocJar = JavadocJar.None()))
             }
         }

--- a/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
@@ -1,0 +1,17 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class MavenPublishConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.vanniktech.maven.publish")
+            extensions.configure<MavenPublishBaseExtension> {
+                publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+                signAllPublications()
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,17 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# Maven Central publishing
+GROUP=dev.mkeeda.arranger
+VERSION_NAME=0.1.0-alpha01
+POM_URL=https://github.com/mkeeda/arranger/
+POM_LICENSE_NAME=Apache-2.0
+POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+POM_SCM_URL=https://github.com/mkeeda/arranger/
+POM_SCM_CONNECTION=scm:git:git://github.com/mkeeda/arranger.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/mkeeda/arranger.git
+POM_DEVELOPER_ID=mkeeda
+POM_DEVELOPER_NAME=mkeeda
+POM_DEVELOPER_URL=https://github.com/mkeeda/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ robolectric = "4.16.1"
 nav3Core = "1.1.0"
 material3AdaptiveNav3 = "1.3.0-alpha10"
 kotlinxSerializationCore = "1.7.3"
+vanniktechMavenPublish = "0.36.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,6 +43,7 @@ kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 spotless-gradlePlugin = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
+vanniktech-maven-publish-gradlePlugin = { group = "com.vanniktech", name = "gradle-maven-publish-plugin", version.ref = "vanniktechMavenPublish" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -50,4 +52,5 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktechMavenPublish" }
 

--- a/richtext-editor/build.gradle.kts
+++ b/richtext-editor/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("arranger.android.library")
+    id("arranger.maven.publish")
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/richtext-editor/gradle.properties
+++ b/richtext-editor/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=arranger-richtext-editor
+POM_NAME=Arranger RichText Editor
+POM_DESCRIPTION=A Compose-based rich text editor component for Android built on the Arranger RichText library.

--- a/richtext/build.gradle.kts
+++ b/richtext/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("arranger.android.library")
+    id("arranger.maven.publish")
 }
 
 android {

--- a/richtext/gradle.properties
+++ b/richtext/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=arranger-richtext
+POM_NAME=Arranger RichText
+POM_DESCRIPTION=A Kotlin library for composing rich text with custom attributes for Android.


### PR DESCRIPTION
## Overview

Sets up an automated Maven Central publishing pipeline using `vanniktech/gradle-maven-publish-plugin` (v0.36.0). When a tag matching `v*` (e.g., `v0.1.0-alpha01`) is pushed, a GitHub Actions workflow automatically builds, signs, and deploys the library artifacts to Maven Central.

Published coordinates:
- `dev.mkeeda.arranger:arranger-richtext`
- `dev.mkeeda.arranger:arranger-richtext-editor`

## Implementation Details

### Version Catalog (`gradle/libs.versions.toml`)
- Added `vanniktech-maven-publish` plugin (v0.36.0) to versions, libraries,
  and plugins sections.

### Convention Plugin (`build-logic`)
- Added `MavenPublishConventionPlugin` registered as `arranger.maven.publish`.
- Applies `com.vanniktech.maven.publish`, configures `publishToMavenCentral()`
  and `AndroidSingleVariantLibrary(javadocJar = JavadocJar.None())`.
- Plugin dependency uses `implementation` scope (required for runtime class loading).
- Signing (`signAllPublications`) is controlled via CI environment variable
  (`ORG_GRADLE_PROJECT_signAllPublications=true`) so local `publishToMavenLocal`
  works without a GPG key.

### POM Metadata
- Common POM properties (GROUP, VERSION_NAME, license, SCM, developer info)
  are defined in the root `gradle.properties`.
- Module-specific properties (`POM_ARTIFACT_ID`, `POM_NAME`, `POM_DESCRIPTION`)
  are placed in each module's own `gradle.properties`:
  - `richtext/gradle.properties`
  - `richtext-editor/gradle.properties`

### Module Changes (`richtext`, `richtext-editor`)
- Applied `id("arranger.maven.publish")` plugin to both library modules.

### GitHub Actions (`.github/workflows/publish.yml`)
- Triggered on tag push matching `v*`.
- Runs `./gradlew publishAndReleaseToMavenCentral --no-configuration-cache`.
- Required GitHub Secrets: `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`,
  `SIGNING_IN_MEMORY_KEY`, `SIGNING_IN_MEMORY_KEY_ID`,
  `SIGNING_IN_MEMORY_KEY_PASSWORD`.

### Documentation (`CONTRIBUTING.md`)
- Added `CONTRIBUTING.md` documenting the versioning strategy (0.x.x phase
  rules with `-alpha`/`-beta` suffixes) and the step-by-step release process
  for maintainers.
- The single source of truth for the version is `VERSION_NAME` in `gradle.properties`.

## Verification

Ran `./gradlew publishToMavenLocal` and confirmed the following artifacts
were generated under `~/.m2/repository/dev/mkeeda/arranger/`:
- `arranger-richtext-0.1.0-alpha01.aar`
- `arranger-richtext-0.1.0-alpha01-sources.jar`
- `arranger-richtext-0.1.0-alpha01.pom`
- `arranger-richtext-editor-*` equivalents