### PR TITLE
docs, feat: update README requirements and expose editor dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ Compared to Android's traditional `SpannableStringBuilder` or Compose's `Annotat
 * **Value Semantics:** The core text data structures are immutable, ensuring thread safety and predictable UI re-rendering, which is highly compatible with Compose.
 * **Type Safety:** We use Kotlin's Extension Functions with receivers to create an intuitive, declarative DSL for composing attributes.
 
+## Installation
+
+Arranger is published to Maven Central. Add the following dependencies to your module's `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    // Core data structures and state management
+    implementation("dev.mkeeda.arranger:arranger-richtext:0.1.0-alpha01")
+
+    // Compose UI integration (RichTextEditor)
+    implementation("dev.mkeeda.arranger:arranger-richtext-editor:0.1.0-alpha01")
+}
+```
+
 ## Basic Usage (Getting Started)
 
 Arranger's biggest selling point is that you can programmatically construct and decorate RichText using a clean DSL. Simply create a `RichTextState`, decorate it with `editAttributes`, and pass it to the `RichTextEditor`.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 > [!WARNING]
 > **Work In Progress**: This library is currently under active development. APIs are unstable and subject to change without notice.
 
+## Requirements
+* **Android API Level 26+**
+* **Jetpack Compose 1.7+**
+
 ## Project Vision & Features
 The goal of "Arranger" is to provide a "declarative, type-safe, and immutable string manipulation experience similar to SwiftUI's `AttributedString`" to Jetpack Compose and Kotlin Multiplatform (KMP). We aim to break away from the tedious, error-prone index manipulations required by the existing `AnnotatedString` and the traditional WYSIWYG approaches.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ## Requirements
 * **Android API Level 26+**
 * **Jetpack Compose 1.7+**
+* **Kotlin 2.3.20+**
 
 ## Project Vision & Features
 The goal of "Arranger" is to provide a "declarative, type-safe, and immutable string manipulation experience similar to SwiftUI's `AttributedString`" to Jetpack Compose and Kotlin Multiplatform (KMP). We aim to break away from the tedious, error-prone index manipulations required by the existing `AnnotatedString` and the traditional WYSIWYG approaches.
@@ -27,11 +28,12 @@ Arranger is published to Maven Central. Add the following dependencies to your m
 
 ```kotlin
 dependencies {
-    // Core data structures and state management
-    implementation("dev.mkeeda.arranger:arranger-richtext:0.1.0-alpha01")
-
-    // Compose UI integration (RichTextEditor)
+    // For Compose UI integration (RichTextEditor).
+    // This automatically includes the core 'arranger-richtext' module.
     implementation("dev.mkeeda.arranger:arranger-richtext-editor:0.1.0-alpha01")
+
+    // Or, if you only need the core data structures without Compose UI:
+    // implementation("dev.mkeeda.arranger:arranger-richtext:0.1.0-alpha01")
 }
 ```
 

--- a/richtext-editor/build.gradle.kts
+++ b/richtext-editor/build.gradle.kts
@@ -17,10 +17,10 @@ android {
 }
 
 dependencies {
-    implementation(project(":richtext"))
+    api(project(":richtext"))
 
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.foundation)
+    api(platform(libs.androidx.compose.bom))
+    api(libs.androidx.compose.foundation)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotest.assertions.core)


### PR DESCRIPTION
## Overview
This PR updates the `README.md` to clarify library requirements and installation instructions ahead of the `v0.1.0-alpha01` release. Additionally, it updates the `richtext-editor` module to expose its required dependencies (the core `richtext` module and Compose Foundation) as `api` dependencies, simplifying integration for users.

## Changes
* **Documentation**: Added the `Requirements` section indicating Android API Level 26+, Jetpack Compose 1.7+, and Kotlin 2.3.20+.
* **Documentation**: Added the `Installation` section with Gradle dependency instructions.
* **Feature/Build**: Changed `implementation` to `api` for `richtext`, `androidx.compose.bom`, and `androidx.compose.foundation` in `richtext-editor/build.gradle.kts`. This ensures users can access core text APIs and Compose primitives automatically when importing the editor module.