### PR TITLE
refactor(richtext): rename RichStringBuffer to RichStringScope

### DIFF
--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichStringScopeComposeExt.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichStringScopeComposeExt.kt
@@ -2,7 +2,7 @@ package dev.mkeeda.arranger.richtext.editor
 
 import androidx.compose.ui.text.TextRange
 import dev.mkeeda.arranger.richtext.AttributeEditScope
-import dev.mkeeda.arranger.richtext.RichStringBuffer
+import dev.mkeeda.arranger.richtext.RichStringScope
 
 /**
  * Applies a set of attribute mutations to the range specified by the given [TextRange].
@@ -11,7 +11,7 @@ import dev.mkeeda.arranger.richtext.RichStringBuffer
  * If the selection is collapsed (cursor with no selection), the resulting range is empty
  * and no attributes are modified.
  */
-public fun RichStringBuffer.editAttributes(
+public fun RichStringScope.editAttributes(
     selection: TextRange,
     editAction: AttributeEditScope.() -> Unit,
 ) {

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.TextRange
 import dev.mkeeda.arranger.richtext.RichSpan
 import dev.mkeeda.arranger.richtext.RichString
-import dev.mkeeda.arranger.richtext.RichStringBuffer
+import dev.mkeeda.arranger.richtext.RichStringScope
 import dev.mkeeda.arranger.richtext.resnapParagraphSpans
 
 @Stable
@@ -37,9 +37,9 @@ public class RichTextState(initialText: RichString) {
 
     /**
      * Edits the underlying [RichString] state using a builder DSL.
-     * This allows you to apply or remove multiple attributes within a [RichStringBuffer].
+     * This allows you to apply or remove multiple attributes within a [RichStringScope].
      */
-    public fun edit(block: RichStringBuffer.() -> Unit) {
+    public fun edit(block: RichStringScope.() -> Unit) {
         spans = richString.edit(block).spans
     }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
@@ -4,7 +4,7 @@ package dev.mkeeda.arranger.richtext
  * A builder DSL for safely mutating multiple text attributes within a specific range.
  */
 public class AttributeEditScope internal constructor(
-    private val buffer: RichStringBuffer,
+    private val buffer: RichStringScope,
     private val range: IntRange,
 ) {
     /**

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
@@ -82,12 +82,12 @@ public data class RichString(
         }
 
     /**
-     * Executes the given [block] on a [RichStringBuffer] scoped to this [RichString],
+     * Executes the given [block] on a [RichStringScope] scoped to this [RichString],
      * and returns a completely new [RichString] carrying the modifications.
      */
-    public fun edit(block: RichStringBuffer.() -> Unit): RichString {
-        val buffer = RichStringBuffer(currentSpans = spans, text = text)
-        buffer.block()
-        return buffer.build(text = text)
+    public fun edit(block: RichStringScope.() -> Unit): RichString {
+        val scope = RichStringScope(currentSpans = spans, text = text)
+        scope.block()
+        return scope.build(text = text)
     }
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
@@ -1,11 +1,13 @@
 package dev.mkeeda.arranger.richtext
 
 /**
- * A buffer class used to safely mutate the attributes of a [RichString] within an `edit` block.
+ * A DSL scope used to safely mutate the attributes of a [RichString] within an `edit` block.
  * All mutations are accumulated internally and used to produce a completely new, immutable [RichString] instance
  * when the block completes.
+ *
+ * Note: This scope does not mutate the text itself. It is scoped exclusively to attribute operations.
  */
-public class RichStringBuffer internal constructor(
+public class RichStringScope internal constructor(
     private var currentSpans: List<RichSpan>,
     private val text: String,
 ) {
@@ -104,7 +106,7 @@ public class RichStringBuffer internal constructor(
      *
      * Note: The [runs] sequence is consumed lazily during iteration. It is expected to be derived
      * from an immutable [RichString] (e.g., via [RichString.runs]), not from any mutable state
-     * within this buffer.
+     * within this scope.
      */
     public fun <T : Any> editAll(
         runs: Sequence<RichRun<T>>,


### PR DESCRIPTION
## Overview

`RichStringBuffer` implied text mutability (similar to `StringBuilder`), but it only supports attribute mutations on immutable text content. This rename clarifies its actual role as a DSL receiver scope for attribute-only edits.

`RichStringScope` follows Compose's `*Scope` naming convention (e.g., `DrawScope`, `LazyListScope`), making its purpose as a scoped DSL receiver immediately clear.

## Implementation Details

- Rename `RichStringBuffer` → `RichStringScope`
- Rename `RichStringBuffer.kt` → `RichStringScope.kt`
- Rename `RichStringBufferComposeExt.kt` → `RichStringScopeComposeExt.kt`
- Update all references across `richtext` and `richtext-editor` modules
- Update KDoc in `RichString.edit { }` and `AttributeEditScope`

## Breaking Change

`RichStringScope` replaces `RichStringBuffer` as the receiver type of `RichString.edit { }` and `RichTextState.edit { }`.
