### PR TITLE
feat(richtext): implement mutually exclusive paragraph attributes

### DIFF
--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolverTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolverTest.kt
@@ -6,7 +6,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
-import dev.mkeeda.arranger.richtext.ParagraphAttributeKey
+import dev.mkeeda.arranger.richtext.AlignmentAttributeKey
+import dev.mkeeda.arranger.richtext.BlockTypeAttributeKey
 import dev.mkeeda.arranger.richtext.SpanAttributeKey
 import dev.mkeeda.arranger.richtext.attributeContainerOf
 import io.kotest.matchers.nulls.shouldBeNull
@@ -22,12 +23,12 @@ class AttributeStyleResolverTest {
         override val defaultValue: String = ""
     }
 
-    private object TestParagraphKey : ParagraphAttributeKey<TextAlign> {
+    private object TestParagraphKey : AlignmentAttributeKey<TextAlign> {
         override val name: String = "TestParagraph"
         override val defaultValue: TextAlign = TextAlign.Unspecified
     }
 
-    private object TestParagraphAndSpanKey : ParagraphAttributeKey<Unit> {
+    private object TestParagraphAndSpanKey : BlockTypeAttributeKey<Unit> {
         override val name: String = "TestCombined"
         override val defaultValue: Unit = Unit
     }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
@@ -88,7 +88,26 @@ public class AttributeContainer private constructor(
         key: AttributeKey<T>,
         value: T,
     ): AttributeContainer {
-        return AttributeContainer(attributes = attributes + (key to value))
+        return plusAny(key, value)
+    }
+
+    private fun plusAny(key: AttributeKey<*>, value: Any?): AttributeContainer {
+        val keysToRemove =
+            if (key is ParagraphAttributeKey<*>) {
+                when (key) {
+                    is BlockTypeAttributeKey<*> -> keys.filterIsInstance<BlockTypeAttributeKey<*>>()
+                    is AlignmentAttributeKey<*> -> keys.filterIsInstance<AlignmentAttributeKey<*>>()
+                }
+            } else {
+                emptyList()
+            }
+
+        if (keysToRemove.isEmpty()) {
+            return AttributeContainer(attributes = attributes + (key to value))
+        }
+
+        val filteredAttributes = attributes.filterKeys { it !in keysToRemove }
+        return AttributeContainer(attributes = filteredAttributes + (key to value))
     }
 
     /**
@@ -103,7 +122,12 @@ public class AttributeContainer private constructor(
     public operator fun plus(other: AttributeContainer): AttributeContainer {
         if (other.attributes.isEmpty()) return this
         if (this.attributes.isEmpty()) return other
-        return AttributeContainer(attributes = attributes + other.attributes)
+
+        var result = this
+        for ((key, value) in other.attributes) {
+            result = result.plusAny(key, value)
+        }
+        return result
     }
 
     /**

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
@@ -106,7 +106,8 @@ public class AttributeContainer private constructor(
             return AttributeContainer(attributes = attributes + (key to value))
         }
 
-        val filteredAttributes = attributes.filterKeys { it !in keysToRemove }
+        val keysToRemoveSet = keysToRemove.toSet()
+        val filteredAttributes = attributes.filterKeys { it !in keysToRemoveSet }
         return AttributeContainer(attributes = filteredAttributes + (key to value))
     }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
@@ -17,7 +17,7 @@ public interface SpanAttributeKey<T> : AttributeKey<T>
 /**
  * A marker interface indicating that the attribute applies to whole paragraphs.
  */
-public interface ParagraphAttributeKey<T> : AttributeKey<T>
+public sealed interface ParagraphAttributeKey<T> : AttributeKey<T>
 
 /**
  * A category interface for paragraph attributes that dictate block structure (e.g., Heading, List, Blockquote).

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeKey.kt
@@ -18,3 +18,15 @@ public interface SpanAttributeKey<T> : AttributeKey<T>
  * A marker interface indicating that the attribute applies to whole paragraphs.
  */
 public interface ParagraphAttributeKey<T> : AttributeKey<T>
+
+/**
+ * A category interface for paragraph attributes that dictate block structure (e.g., Heading, List, Blockquote).
+ * Only one BlockType attribute can be active in a given paragraph.
+ */
+public interface BlockTypeAttributeKey<T> : ParagraphAttributeKey<T>
+
+/**
+ * A category interface for paragraph attributes that control the alignment of its contents.
+ * Only one Alignment attribute can be active in a given paragraph.
+ */
+public interface AlignmentAttributeKey<T> : ParagraphAttributeKey<T>

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/Attributes.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/Attributes.kt
@@ -102,7 +102,7 @@ public enum class HeadingLevel {
 /**
  * A semantic marker indicating the heading level of the paragraph.
  */
-public object HeadingKey : ParagraphAttributeKey<HeadingLevel> {
+public object HeadingKey : BlockTypeAttributeKey<HeadingLevel> {
     override val name: String = "heading"
     override val defaultValue: HeadingLevel = HeadingLevel.Unspecified
 }
@@ -121,7 +121,7 @@ public enum class TextAlignment {
 /**
  * A semantic marker indicating the horizontal text alignment of the paragraph.
  */
-public object TextAlignmentKey : ParagraphAttributeKey<TextAlignment> {
+public object TextAlignmentKey : AlignmentAttributeKey<TextAlignment> {
     override val name: String = "textAlignment"
     override val defaultValue: TextAlignment = TextAlignment.Unspecified
 }
@@ -129,7 +129,7 @@ public object TextAlignmentKey : ParagraphAttributeKey<TextAlignment> {
 /**
  * A semantic marker indicating that the paragraph is a blockquote.
  */
-public object BlockquoteKey : ParagraphAttributeKey<Unit> {
+public object BlockquoteKey : BlockTypeAttributeKey<Unit> {
     override val name: String = "blockquote"
     override val defaultValue: Unit = Unit
 }
@@ -150,7 +150,7 @@ public enum class ListIndentLevel {
 /**
  * A semantic marker indicating that the paragraph is a bullet list item.
  */
-public object BulletListKey : ParagraphAttributeKey<ListIndentLevel> {
+public object BulletListKey : BlockTypeAttributeKey<ListIndentLevel> {
     override val name: String = "bulletList"
     override val defaultValue: ListIndentLevel = ListIndentLevel.Unspecified
 }
@@ -158,7 +158,7 @@ public object BulletListKey : ParagraphAttributeKey<ListIndentLevel> {
 /**
  * A semantic marker indicating that the paragraph is an ordered list item.
  */
-public object OrderedListKey : ParagraphAttributeKey<ListIndentLevel> {
+public object OrderedListKey : BlockTypeAttributeKey<ListIndentLevel> {
     override val name: String = "orderedList"
     override val defaultValue: ListIndentLevel = ListIndentLevel.Unspecified
 }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
@@ -58,22 +58,9 @@ public class RichStringScope
             checkRange(range)
             val snappedRange = range.snapToParagraphs(text)
 
-            val isBlockType = key is BlockTypeAttributeKey<*>
-            val isAlignment = key is AlignmentAttributeKey<*>
-
             currentSpans =
                 currentSpans.transformSpans(targetRange = snappedRange) { attributes ->
-                    var newAttributes = attributes
-                    if (isBlockType) {
-                        newAttributes.keys.filterIsInstance<BlockTypeAttributeKey<*>>().forEach {
-                            newAttributes -= it
-                        }
-                    } else if (isAlignment) {
-                        newAttributes.keys.filterIsInstance<AlignmentAttributeKey<*>>().forEach {
-                            newAttributes -= it
-                        }
-                    }
-                    newAttributes.plus(key, value)
+                    attributes.plus(key, value)
                 }
         }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
@@ -57,9 +57,23 @@ public class RichStringScope
         ) {
             checkRange(range)
             val snappedRange = range.snapToParagraphs(text)
+
+            val isBlockType = key is BlockTypeAttributeKey<*>
+            val isAlignment = key is AlignmentAttributeKey<*>
+
             currentSpans =
                 currentSpans.transformSpans(targetRange = snappedRange) { attributes ->
-                    attributes.plus(key, value)
+                    var newAttributes = attributes
+                    if (isBlockType) {
+                        newAttributes.keys.filterIsInstance<BlockTypeAttributeKey<*>>().forEach {
+                            newAttributes -= it
+                        }
+                    } else if (isAlignment) {
+                        newAttributes.keys.filterIsInstance<AlignmentAttributeKey<*>>().forEach {
+                            newAttributes -= it
+                        }
+                    }
+                    newAttributes.plus(key, value)
                 }
         }
 

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditParagraphTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditParagraphTest.kt
@@ -105,7 +105,6 @@ class RichStringEditParagraphTest {
                 // Apply attributes to the entire text
                 editAttributes(range = paragraphText.indices) {
                     headingLevel(HeadingLevel.H1)
-                    blockquote()
                     textAlignment(TextAlignment.Center)
                 }
             }
@@ -116,7 +115,6 @@ class RichStringEditParagraphTest {
                 val line2Start = paragraphText.indexOf("Line2")
                 editAttributes(range = line2Start..line2Start) {
                     clearHeadingLevel()
-                    clearBlockquote()
                     clearTextAlignment()
                 }
             }
@@ -127,5 +125,102 @@ class RichStringEditParagraphTest {
         headingRuns shouldHaveSize 2
         headingRuns[0] shouldBe RichRun(text = "Line1\n", range = 0..5, value = HeadingLevel.H1)
         headingRuns[1] shouldBe RichRun(text = "Line3", range = 12..16, value = HeadingLevel.H1)
+    }
+
+    @Test
+    fun `setParagraphAttribute excludes attributes of the same category`() {
+        val richString = RichString(text = "Paragraph")
+
+        val actual =
+            richString.edit {
+                // Setup: apply OrderedList (BlockType)
+                editAttributes {
+                    orderedList(ListIndentLevel.Level1)
+                }
+                // Action: apply Heading (BlockType)
+                editAttributes {
+                    headingLevel(HeadingLevel.H1)
+                }
+            }
+
+        val orderedListRuns = actual.runs(OrderedListKey).toList()
+        orderedListRuns shouldHaveSize 0
+
+        val headingRuns = actual.runs(HeadingKey).toList()
+        headingRuns shouldHaveSize 1
+        headingRuns[0] shouldBe RichRun(text = "Paragraph", range = 0..8, value = HeadingLevel.H1)
+    }
+
+    @Test
+    fun `setParagraphAttribute coexists with attributes of different categories`() {
+        val richString = RichString(text = "Paragraph")
+
+        val actual =
+            richString.edit {
+                // Setup: apply Heading (BlockType)
+                editAttributes {
+                    headingLevel(HeadingLevel.H1)
+                }
+                // Action: apply TextAlignment (Alignment)
+                editAttributes {
+                    textAlignment(TextAlignment.Center)
+                }
+            }
+
+        val headingRuns = actual.runs(HeadingKey).toList()
+        headingRuns shouldHaveSize 1
+        headingRuns[0] shouldBe RichRun(text = "Paragraph", range = 0..8, value = HeadingLevel.H1)
+
+        val alignRuns = actual.runs(TextAlignmentKey).toList()
+        alignRuns shouldHaveSize 1
+        alignRuns[0] shouldBe RichRun(text = "Paragraph", range = 0..8, value = TextAlignment.Center)
+    }
+
+    @Test
+    fun `setParagraphAttribute correctly splits spans when applied to middle paragraph`() {
+        val richString = RichString(text = paragraphText) // Line1\nLine2\nLine3
+
+        val actual =
+            richString.edit {
+                // Setup: apply OrderedList to all
+                editAttributes {
+                    orderedList(ListIndentLevel.Level1)
+                }
+                // Action: apply Heading to the middle paragraph only
+                val line2Start = paragraphText.indexOf("Line2")
+                editAttributes(range = line2Start..line2Start) {
+                    headingLevel(HeadingLevel.H2)
+                }
+            }
+
+        val orderedListRuns = actual.runs(OrderedListKey).toList()
+        orderedListRuns shouldHaveSize 2
+        orderedListRuns[0] shouldBe RichRun(text = "Line1\n", range = 0..5, value = ListIndentLevel.Level1)
+        orderedListRuns[1] shouldBe RichRun(text = "Line3", range = 12..16, value = ListIndentLevel.Level1)
+
+        val headingRuns = actual.runs(HeadingKey).toList()
+        headingRuns shouldHaveSize 1
+        headingRuns[0] shouldBe RichRun(text = "Line2\n", range = 6..11, value = HeadingLevel.H2)
+    }
+
+    @Test
+    fun `setParagraphAttribute is idempotent when reapplying the same attribute`() {
+        val richString = RichString(text = "Paragraph")
+
+        val actual =
+            richString.edit {
+                // Setup: apply Heading (BlockType)
+                editAttributes {
+                    headingLevel(HeadingLevel.H1)
+                }
+                // Action: apply Heading again
+                editAttributes {
+                    headingLevel(HeadingLevel.H1)
+                }
+            }
+
+        val headingRuns = actual.runs(HeadingKey).toList()
+        headingRuns shouldHaveSize 1
+        headingRuns[0] shouldBe RichRun(text = "Paragraph", range = 0..8, value = HeadingLevel.H1)
     }
 }


### PR DESCRIPTION
## Overview
This PR implements mutual exclusion for paragraph attributes (e.g., `Heading`, `OrderedList`) to ensure that conflicting block styles or alignments cannot be active on the same paragraph simultaneously.

## Implementation Details
- **Added Category Interfaces**: Introduced `BlockTypeAttributeKey` and `AlignmentAttributeKey` as sub-interfaces of `ParagraphAttributeKey` to group mutually exclusive attributes via the type system.
- **Updated Existing Attributes**: Updated `HeadingKey`, `BlockquoteKey`, `BulletListKey`, and `OrderedListKey` to implement `BlockTypeAttributeKey`. Updated `TextAlignmentKey` to implement `AlignmentAttributeKey`.
- **Enforced Mutual Exclusion**: Modified `RichStringScope.setParagraphAttribute` to automatically remove any existing attributes that share the same category interface before applying a new attribute.
- **Added Unit Tests**: Added comprehensive TDD unit tests to verify:
  - Exclusive application of attributes within the same category.
  - Coexistence of attributes from different categories.
  - Correct splitting behavior when applying block styles to middle paragraphs of a list.
  - Idempotent behavior when reapplying the exact same attribute.