### PR TITLE
chore: verify roborazzi ci artifact upload

### DIFF
--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/DefaultAttributeStyleResolver.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/DefaultAttributeStyleResolver.kt
@@ -62,7 +62,7 @@ public val DefaultAttributeStyleResolver: AttributeStyleResolver =
         }
         spanStyle(HeadingKey) { level ->
             when (level) {
-                HeadingLevel.H1 -> SpanStyle(fontSize = 32.sp, fontWeight = FontWeight.Bold)
+                HeadingLevel.H1 -> SpanStyle(fontSize = 40.sp, fontWeight = FontWeight.Bold)
                 HeadingLevel.H2 -> SpanStyle(fontSize = 24.sp, fontWeight = FontWeight.Bold)
                 HeadingLevel.H3 -> SpanStyle(fontSize = 20.sp, fontWeight = FontWeight.Bold)
                 HeadingLevel.H4 -> SpanStyle(fontSize = 16.sp, fontWeight = FontWeight.Bold)


### PR DESCRIPTION
## Overview
This is a test PR to verify the GitHub Actions setup implemented in PR #33. It intentionally introduces a visual regression (changes H1 font size from 32sp to 40sp) to ensure the `verifyRoborazziDebug` step correctly detects the failure and uploads the diff artifact.

## Implementation Details
- Modified `DefaultAttributeStyleResolver.kt` to change `HeadingLevel.H1` size.