### PR TITLE
chore: release v0.2.0-alpha02

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Arranger is published to Maven Central. Add the following dependencies to your m
 dependencies {
     // For Compose UI integration (RichTextEditor).
     // This automatically includes the core 'arranger-richtext' module.
-    implementation("dev.mkeeda.arranger:arranger-richtext-editor:0.2.0-alpha01")
+    implementation("dev.mkeeda.arranger:arranger-richtext-editor:0.2.0-alpha02")
 
     // Or, if you only need the core data structures without Compose UI:
-    // implementation("dev.mkeeda.arranger:arranger-richtext:0.2.0-alpha01")
+    // implementation("dev.mkeeda.arranger:arranger-richtext:0.2.0-alpha02")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ kotlin.code.style=official
 
 # Maven Central publishing
 GROUP=dev.mkeeda.arranger
-VERSION_NAME=0.2.0-alpha01
+VERSION_NAME=0.2.0-alpha02
 POM_URL=https://github.com/mkeeda/arranger/
 POM_LICENSE_NAME=Apache-2.0
 POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
## Overview
Prepare for the `v0.2.0-alpha02` release by bumping the version numbers.

## Implementation Details
- Bump `VERSION_NAME` in `gradle.properties` to `0.2.0-alpha02`.
- Update dependency instructions in `README.md` to use the new version `0.2.0-alpha02`.