### PR TITLE
refactor(sample): move customMarkerResolver to top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ fun OrderedListSample(modifier: Modifier = Modifier) {
 You can customize the list markers by providing a `ListMarkerResolver` to the `RichTextEditor`. This allows you to use different symbols, letters, or parentheses for your lists.
 
 ```kotlin
+private val customMarkerResolver = ListMarkerResolver { item ->
+    when (item) {
+        is BulletListItem -> "✔️ "
+        is OrderedListItem -> "${('a' + item.index - 1)}) "
+    }
+}
+
 @Composable
 fun CustomListMarkerSample(modifier: Modifier = Modifier) {
     val initialText = "Checklist:\n" +
@@ -224,15 +231,6 @@ fun CustomListMarkerSample(modifier: Modifier = Modifier) {
                 }
             }
         )
-    }
-
-    val customMarkerResolver = remember {
-        ListMarkerResolver { item ->
-            when (item) {
-                is BulletListItem -> "✔️ "
-                is OrderedListItem -> "${('a' + item.index - 1)}) "
-            }
-        }
     }
 
     RichTextEditor(

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ListFormattingSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ListFormattingSample.kt
@@ -120,6 +120,14 @@ fun OrderedListSample(modifier: Modifier = Modifier) {
     )
 }
 
+private val customMarkerResolver =
+    ListMarkerResolver { item ->
+        when (item) {
+            is BulletListItem -> "✔️ "
+            is OrderedListItem -> "${('a' + item.index - 1)}) "
+        }
+    }
+
 @Composable
 fun CustomListMarkerSample(modifier: Modifier = Modifier) {
     val initialText =
@@ -150,16 +158,6 @@ fun CustomListMarkerSample(modifier: Modifier = Modifier) {
                         }
                     },
             )
-        }
-
-    val customMarkerResolver =
-        remember {
-            ListMarkerResolver { item ->
-                when (item) {
-                    is BulletListItem -> "✔️ "
-                    is OrderedListItem -> "${('a' + item.index - 1)}) "
-                }
-            }
         }
 
     RichTextEditor(


### PR DESCRIPTION
This PR removes the unnecessary `remember` block for `customMarkerResolver` in `CustomListMarkerSample` and extracts it to a top-level `val`, as it is a stateless instance.

This mirrors the recent change made to `customResolver` in `CustomAttributeSample.kt`.
It also updates the corresponding documentation snippet in `README.md`.