### PR TITLE
feat(richtext-editor): support explicitly turning off inherited formatting at cursor

### DIFF
--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.TextRange
+import dev.mkeeda.arranger.richtext.AttributeContainer
+import dev.mkeeda.arranger.richtext.AttributeKey
 import dev.mkeeda.arranger.richtext.RichSpan
 import dev.mkeeda.arranger.richtext.RichString
 import dev.mkeeda.arranger.richtext.resnapParagraphSpans
@@ -19,6 +21,18 @@ public class RichTextState(initialText: RichString) {
     // The Single Source of Truth for spans
     private var spans: List<RichSpan> by mutableStateOf(initialText.spans)
 
+    /**
+     * Attributes that will be applied to the next character typed via the keyboard.
+     *
+     * These attributes only affect user keyboard input — they are NOT applied
+     * by programmatic [edit] operations. Use [edit] with explicit attribute
+     * parameters (e.g., `insert(index, text) { bold() }`) for programmatic control.
+     *
+     * Typing attributes are automatically cleared when the cursor position changes
+     * without text input (e.g., tapping a different position, arrow key navigation).
+     */
+    private var typingAttributes: AttributeContainer? by mutableStateOf(null)
+
     // Computed property representing the complete rich text state
     public val richString: RichString
         get() =
@@ -26,6 +40,80 @@ public class RichTextState(initialText: RichString) {
                 text = textFieldState.text.toString(),
                 spans = spans,
             )
+
+    /**
+     * The merged attributes at the current cursor position.
+     *
+     * When [typingAttributes] is set, returns the cursor's inherited attributes
+     * overlaid with the typing overrides. Otherwise, returns the attributes of
+     * the character immediately before the cursor.
+     *
+     * Returns [AttributeContainer.empty] when:
+     * - The text is empty
+     * - The cursor is at position 0 with no typing attributes
+     * - A text range is selected (non-collapsed selection)
+     */
+    public val currentAttributes: AttributeContainer
+        get() {
+            if (!selection.collapsed) {
+                return AttributeContainer.empty()
+            }
+
+            val cursorPosition = selection.start
+            val typingAttr = typingAttributes
+
+            val inheritedAttributes =
+                if (cursorPosition > 0 && cursorPosition <= textFieldState.text.length) {
+                    val indexBeforeCursor = cursorPosition - 1
+                    val spansBeforeCursor = spans.filter { indexBeforeCursor in it.range }
+                    spansBeforeCursor.fold(AttributeContainer.empty()) { acc, span ->
+                        acc + span.attributes
+                    }
+                } else {
+                    AttributeContainer.empty()
+                }
+
+            return if (typingAttr != null) {
+                inheritedAttributes + typingAttr
+            } else {
+                inheritedAttributes
+            }
+        }
+
+    /**
+     * Adds or overwrites a single attribute in the current typing attributes.
+     * Has no effect when a text range is selected (non-collapsed selection).
+     *
+     * @see typingAttributes
+     */
+    public fun <T> setTypingAttribute(
+        key: AttributeKey<T>,
+        value: T,
+    ) {
+        if (!selection.collapsed) return
+        val current = typingAttributes ?: AttributeContainer.empty()
+        typingAttributes = current + (key to value)
+    }
+
+    /**
+     * Removes a single attribute from the current typing attributes.
+     * Has no effect when a text range is selected (non-collapsed selection).
+     *
+     * @see typingAttributes
+     */
+    public fun <T> removeTypingAttribute(key: AttributeKey<T>) {
+        if (!selection.collapsed) return
+        val current = typingAttributes ?: return
+        val updated = current - key
+        typingAttributes = if (updated.isEmpty()) null else updated
+    }
+
+    /**
+     * Clears all typing attributes, reverting to the cursor's inherited attributes.
+     */
+    public fun clearTypingAttributes() {
+        typingAttributes = null
+    }
 
     /**
      * The current selection range within the text field.
@@ -49,22 +137,44 @@ public class RichTextState(initialText: RichString) {
 
     @OptIn(ExperimentalFoundationApi::class)
     internal fun updateRichString(buffer: TextFieldBuffer) {
-        if (buffer.changes.changeCount == 0) return
+        if (buffer.changes.changeCount == 0) {
+            clearTypingAttributes()
+            return
+        }
 
-        val shiftedSpans =
+        val typingAttr = typingAttributes
+
+        val newSpans =
             (0 until buffer.changes.changeCount).fold(spans) { currentSpans, i ->
                 val originalRange = buffer.changes.getOriginalRange(i)
                 val range = buffer.changes.getRange(i)
 
-                currentSpans.shiftSpans(
-                    editStart = originalRange.min,
-                    editEnd = originalRange.max,
-                    newLength = range.length,
-                    offsetDiff = range.length - originalRange.length,
-                )
+                var updatedSpans =
+                    currentSpans.shiftSpans(
+                        editStart = originalRange.min,
+                        editEnd = originalRange.max,
+                        newLength = range.length,
+                        offsetDiff = range.length - originalRange.length,
+                    )
+
+                // Apply typing attributes to the inserted text
+                if (typingAttr != null && range.length > originalRange.length) {
+                    val insertStart = originalRange.min
+                    val insertEnd = insertStart + range.length - 1
+                    if (insertStart <= insertEnd) {
+                        updatedSpans = updatedSpans +
+                            RichSpan(
+                                range = insertStart..insertEnd,
+                                attributes = typingAttr,
+                            )
+                    }
+                }
+
+                updatedSpans
             }
 
-        this.spans = shiftedSpans.resnapParagraphSpans(buffer.toString())
+        this.spans = newSpans.resnapParagraphSpans(buffer.toString())
+        clearTypingAttributes()
     }
 }
 

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -34,7 +35,8 @@ public class RichTextState(initialText: RichString) {
      * Typing attributes are automatically cleared when the cursor position changes
      * without text input (e.g., tapping a different position, arrow key navigation).
      */
-    private var typingAttributes: AttributeContainer? by mutableStateOf(null)
+    public var typingAttributes: AttributeContainer? by mutableStateOf(null)
+        private set
 
     /**
      * Attributes explicitly removed by the user at the cursor position.
@@ -42,6 +44,12 @@ public class RichTextState(initialText: RichString) {
      * so that inherited attributes don't apply.
      */
     private var removedTypingAttributes: Set<AttributeKey<*>>? by mutableStateOf(null)
+
+    /**
+     * Records the selection state at the exact moment typing attributes were modified.
+     * Used to detect true cursor movement vs. non-text-changing buffer updates.
+     */
+    private var typingAttributesAnchor: TextRange? = null
 
     // Computed property representing the complete rich text state
     public val richString: RichString
@@ -51,49 +59,53 @@ public class RichTextState(initialText: RichString) {
                 spans = spans,
             )
 
-    /**
-     * The merged attributes at the current cursor position.
-     *
-     * When [typingAttributes] is set, returns the cursor's inherited attributes
-     * overlaid with the typing overrides. Otherwise, returns the attributes of
-     * the character immediately before the cursor.
-     *
-     * Returns [AttributeContainer.empty] when:
-     * - The text is empty
-     * - The cursor is at position 0 with no typing attributes
-     */
-    public val currentAttributes: AttributeContainer
-        get() {
+    private val currentAttributesState =
+        derivedStateOf {
             if (!selection.collapsed) {
                 val selStart = selection.min
                 val selEnd = selection.max
-                var intersection: AttributeContainer? = null
+                val selectionLength = selEnd - selStart
 
-                for (i in selStart until selEnd) {
-                    val charAttrs =
-                        spans.filter { i in it.range }.fold(AttributeContainer.empty()) { acc, span ->
-                            acc + span.attributes
-                        }
-                    if (intersection == null) {
-                        intersection = charAttrs
-                    } else {
-                        var newIntersection = AttributeContainer.empty()
-                        for (key in intersection.keys) {
-                            if (charAttrs.containsKey(key)) {
-                                @Suppress("UNCHECKED_CAST")
-                                val k = key as AttributeKey<Any>
-                                val v1 = intersection.getOrDefault(k)
-                                val v2 = charAttrs.getOrDefault(k)
-                                if (v1 == v2) {
-                                    newIntersection += k to v1
-                                }
-                            }
-                        }
-                        intersection = newIntersection
+                val activeSpans =
+                    spans.filter { span ->
+                        maxOf(selStart, span.range.first) < minOf(selEnd, span.range.last + 1)
                     }
-                    if (intersection.isEmpty()) break
+                if (activeSpans.isEmpty()) return@derivedStateOf AttributeContainer.empty()
+
+                // Optimization: Instead of filtering spans for every character index (O(n * m)),
+                // we calculate the intersection by tracking the number of characters each
+                // attribute value covers within the selection.
+                // Since spans with the same attribute key do not overlap in the buffer,
+                // if an attribute value's coverage length equals the selection length, it's in the intersection.
+                val attributeCounts = mutableMapOf<AttributeKey<*>, MutableMap<Any, Int>>()
+
+                for (span in activeSpans) {
+                    val overlapStart = maxOf(selStart, span.range.first)
+                    val overlapEnd = minOf(selEnd, span.range.last + 1)
+                    val overlapLength = overlapEnd - overlapStart
+
+                    if (overlapLength > 0) {
+                        for (key in span.attributes.keys) {
+                            @Suppress("UNCHECKED_CAST")
+                            val k = key as AttributeKey<Any>
+                            val value = span.attributes.getOrDefault(k)
+                            val valueCounts = attributeCounts.getOrPut(k) { mutableMapOf() }
+                            valueCounts[value as Any] = valueCounts.getOrDefault(value, 0) + overlapLength
+                        }
+                    }
                 }
-                return intersection ?: AttributeContainer.empty()
+
+                var intersection = AttributeContainer.empty()
+                for ((key, valueCounts) in attributeCounts) {
+                    for ((value, count) in valueCounts) {
+                        if (count == selectionLength) {
+                            @Suppress("UNCHECKED_CAST")
+                            val k = key as AttributeKey<Any>
+                            intersection += k to value
+                        }
+                    }
+                }
+                return@derivedStateOf intersection
             }
 
             val cursorPosition = selection.start
@@ -120,8 +132,22 @@ public class RichTextState(initialText: RichString) {
                     finalAttrs -= key
                 }
             }
-            return finalAttrs
+            finalAttrs
         }
+
+    /**
+     * The merged attributes at the current cursor position.
+     *
+     * When [typingAttributes] is set, returns the cursor's inherited attributes
+     * overlaid with the typing overrides. Otherwise, returns the attributes of
+     * the character immediately before the cursor.
+     *
+     * Returns [AttributeContainer.empty] when:
+     * - The text is empty
+     * - The cursor is at position 0 with no typing attributes
+     */
+    public val currentAttributes: AttributeContainer
+        get() = currentAttributesState.value
 
     /**
      * Adds or overwrites a single attribute in the current typing attributes.
@@ -142,6 +168,8 @@ public class RichTextState(initialText: RichString) {
             val updated = currentRemoved - key
             removedTypingAttributes = if (updated.isEmpty()) null else updated
         }
+
+        typingAttributesAnchor = selection
     }
 
     /**
@@ -161,6 +189,7 @@ public class RichTextState(initialText: RichString) {
             val currentRemoved = removedTypingAttributes ?: emptySet()
             removedTypingAttributes = currentRemoved + key
         }
+        typingAttributesAnchor = selection
     }
 
     /**
@@ -169,6 +198,7 @@ public class RichTextState(initialText: RichString) {
     public fun clearTypingAttributes() {
         typingAttributes = null
         removedTypingAttributes = null
+        typingAttributesAnchor = null
     }
 
     /**
@@ -194,7 +224,12 @@ public class RichTextState(initialText: RichString) {
     @OptIn(ExperimentalFoundationApi::class)
     internal fun updateRichString(buffer: TextFieldBuffer) {
         if (buffer.changes.changeCount == 0) {
-            clearTypingAttributes()
+            // Compose may trigger input transformations for non-text changes.
+            // We only clear typing attributes if the cursor actually moved away
+            // from where the attributes were originally set.
+            if (typingAttributesAnchor != null && buffer.selection != typingAttributesAnchor) {
+                clearTypingAttributes()
+            }
             return
         }
 

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -59,82 +59,6 @@ public class RichTextState(initialText: RichString) {
                 spans = spans,
             )
 
-    private val currentAttributesState =
-        derivedStateOf {
-            if (!selection.collapsed) {
-                val selStart = selection.min
-                val selEnd = selection.max
-                val selectionLength = selEnd - selStart
-
-                val activeSpans =
-                    spans.filter { span ->
-                        maxOf(selStart, span.range.first) < minOf(selEnd, span.range.last + 1)
-                    }
-                if (activeSpans.isEmpty()) return@derivedStateOf AttributeContainer.empty()
-
-                // Optimization: Instead of filtering spans for every character index (O(n * m)),
-                // we calculate the intersection by tracking the number of characters each
-                // attribute value covers within the selection.
-                // Since spans with the same attribute key do not overlap in the buffer,
-                // if an attribute value's coverage length equals the selection length, it's in the intersection.
-                val attributeCounts = mutableMapOf<AttributeKey<*>, MutableMap<Any, Int>>()
-
-                for (span in activeSpans) {
-                    val overlapStart = maxOf(selStart, span.range.first)
-                    val overlapEnd = minOf(selEnd, span.range.last + 1)
-                    val overlapLength = overlapEnd - overlapStart
-
-                    if (overlapLength > 0) {
-                        for (key in span.attributes.keys) {
-                            @Suppress("UNCHECKED_CAST")
-                            val k = key as AttributeKey<Any>
-                            val value = span.attributes.getOrDefault(k)
-                            val valueCounts = attributeCounts.getOrPut(k) { mutableMapOf() }
-                            valueCounts[value as Any] = valueCounts.getOrDefault(value, 0) + overlapLength
-                        }
-                    }
-                }
-
-                var intersection = AttributeContainer.empty()
-                for ((key, valueCounts) in attributeCounts) {
-                    for ((value, count) in valueCounts) {
-                        if (count == selectionLength) {
-                            @Suppress("UNCHECKED_CAST")
-                            val k = key as AttributeKey<Any>
-                            intersection += k to value
-                        }
-                    }
-                }
-                return@derivedStateOf intersection
-            }
-
-            val cursorPosition = selection.start
-            val typingAttr = typingAttributes
-            val removedAttr = removedTypingAttributes
-
-            val inheritedAttributes =
-                if (cursorPosition > 0 && cursorPosition <= textFieldState.text.length) {
-                    val indexBeforeCursor = cursorPosition - 1
-                    val spansBeforeCursor = spans.filter { indexBeforeCursor in it.range }
-                    spansBeforeCursor.fold(AttributeContainer.empty()) { acc, span ->
-                        acc + span.attributes
-                    }
-                } else {
-                    AttributeContainer.empty()
-                }
-
-            var finalAttrs = inheritedAttributes
-            if (typingAttr != null) {
-                finalAttrs += typingAttr
-            }
-            if (removedAttr != null) {
-                removedAttr.forEach { key ->
-                    finalAttrs -= key
-                }
-            }
-            finalAttrs
-        }
-
     /**
      * The merged attributes at the current cursor position.
      *
@@ -146,8 +70,80 @@ public class RichTextState(initialText: RichString) {
      * - The text is empty
      * - The cursor is at position 0 with no typing attributes
      */
-    public val currentAttributes: AttributeContainer
-        get() = currentAttributesState.value
+    public val currentAttributes: AttributeContainer by derivedStateOf {
+        if (!selection.collapsed) {
+            val selStart = selection.min
+            val selEnd = selection.max
+            val selectionLength = selEnd - selStart
+
+            val activeSpans =
+                spans.filter { span ->
+                    maxOf(selStart, span.range.first) < minOf(selEnd, span.range.last + 1)
+                }
+            if (activeSpans.isEmpty()) return@derivedStateOf AttributeContainer.empty()
+
+            // Optimization: Instead of filtering spans for every character index (O(n * m)),
+            // we calculate the intersection by tracking the number of characters each
+            // attribute value covers within the selection.
+            // Since spans with the same attribute key do not overlap in the buffer,
+            // if an attribute value's coverage length equals the selection length, it's in the intersection.
+            val attributeCounts = mutableMapOf<AttributeKey<*>, MutableMap<Any, Int>>()
+
+            for (span in activeSpans) {
+                val overlapStart = maxOf(selStart, span.range.first)
+                val overlapEnd = minOf(selEnd, span.range.last + 1)
+                val overlapLength = overlapEnd - overlapStart
+
+                if (overlapLength > 0) {
+                    for (key in span.attributes.keys) {
+                        @Suppress("UNCHECKED_CAST")
+                        val k = key as AttributeKey<Any>
+                        val value = span.attributes.getOrDefault(k)
+                        val valueCounts = attributeCounts.getOrPut(k) { mutableMapOf() }
+                        valueCounts[value as Any] = valueCounts.getOrDefault(value, 0) + overlapLength
+                    }
+                }
+            }
+
+            var intersection = AttributeContainer.empty()
+            for ((key, valueCounts) in attributeCounts) {
+                for ((value, count) in valueCounts) {
+                    if (count == selectionLength) {
+                        @Suppress("UNCHECKED_CAST")
+                        val k = key as AttributeKey<Any>
+                        intersection += k to value
+                    }
+                }
+            }
+            return@derivedStateOf intersection
+        }
+
+        val cursorPosition = selection.start
+        val typingAttr = typingAttributes
+        val removedAttr = removedTypingAttributes
+
+        val inheritedAttributes =
+            if (cursorPosition > 0 && cursorPosition <= textFieldState.text.length) {
+                val indexBeforeCursor = cursorPosition - 1
+                val spansBeforeCursor = spans.filter { indexBeforeCursor in it.range }
+                spansBeforeCursor.fold(AttributeContainer.empty()) { acc, span ->
+                    acc + span.attributes
+                }
+            } else {
+                AttributeContainer.empty()
+            }
+
+        var finalAttrs = inheritedAttributes
+        if (typingAttr != null) {
+            finalAttrs += typingAttr
+        }
+        if (removedAttr != null) {
+            removedAttr.forEach { key ->
+                finalAttrs -= key
+            }
+        }
+        finalAttrs
+    }
 
     /**
      * Adds or overwrites a single attribute in the current typing attributes.

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -12,6 +12,7 @@ import dev.mkeeda.arranger.richtext.AttributeContainer
 import dev.mkeeda.arranger.richtext.AttributeKey
 import dev.mkeeda.arranger.richtext.RichSpan
 import dev.mkeeda.arranger.richtext.RichString
+import dev.mkeeda.arranger.richtext.mergeSpan
 import dev.mkeeda.arranger.richtext.resnapParagraphSpans
 
 @Stable
@@ -51,12 +52,39 @@ public class RichTextState(initialText: RichString) {
      * Returns [AttributeContainer.empty] when:
      * - The text is empty
      * - The cursor is at position 0 with no typing attributes
-     * - A text range is selected (non-collapsed selection)
      */
     public val currentAttributes: AttributeContainer
         get() {
             if (!selection.collapsed) {
-                return AttributeContainer.empty()
+                val selStart = selection.min
+                val selEnd = selection.max
+                var intersection: AttributeContainer? = null
+
+                for (i in selStart until selEnd) {
+                    val charAttrs =
+                        spans.filter { i in it.range }.fold(AttributeContainer.empty()) { acc, span ->
+                            acc + span.attributes
+                        }
+                    if (intersection == null) {
+                        intersection = charAttrs
+                    } else {
+                        var newIntersection = AttributeContainer.empty()
+                        for (key in intersection.keys) {
+                            if (charAttrs.containsKey(key)) {
+                                @Suppress("UNCHECKED_CAST")
+                                val k = key as AttributeKey<Any>
+                                val v1 = intersection.getOrDefault(k)
+                                val v2 = charAttrs.getOrDefault(k)
+                                if (v1 == v2) {
+                                    newIntersection += k to v1
+                                }
+                            }
+                        }
+                        intersection = newIntersection
+                    }
+                    if (intersection.isEmpty()) break
+                }
+                return intersection ?: AttributeContainer.empty()
             }
 
             val cursorPosition = selection.start
@@ -162,10 +190,12 @@ public class RichTextState(initialText: RichString) {
                     val insertStart = originalRange.min
                     val insertEnd = insertStart + range.length - 1
                     if (insertStart <= insertEnd) {
-                        updatedSpans = updatedSpans +
-                            RichSpan(
-                                range = insertStart..insertEnd,
-                                attributes = typingAttr,
+                        updatedSpans =
+                            updatedSpans.mergeSpan(
+                                RichSpan(
+                                    range = insertStart..insertEnd,
+                                    attributes = typingAttr,
+                                ),
                             )
                     }
                 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -10,8 +10,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.TextRange
 import dev.mkeeda.arranger.richtext.AttributeContainer
 import dev.mkeeda.arranger.richtext.AttributeKey
+import dev.mkeeda.arranger.richtext.ParagraphAttributeKey
 import dev.mkeeda.arranger.richtext.RichSpan
 import dev.mkeeda.arranger.richtext.RichString
+import dev.mkeeda.arranger.richtext.SpanAttributeKey
 import dev.mkeeda.arranger.richtext.mergeSpan
 import dev.mkeeda.arranger.richtext.resnapParagraphSpans
 
@@ -33,6 +35,13 @@ public class RichTextState(initialText: RichString) {
      * without text input (e.g., tapping a different position, arrow key navigation).
      */
     private var typingAttributes: AttributeContainer? by mutableStateOf(null)
+
+    /**
+     * Attributes explicitly removed by the user at the cursor position.
+     * When text is typed, these attributes will be forcefully cleared from the new text
+     * so that inherited attributes don't apply.
+     */
+    private var removedTypingAttributes: Set<AttributeKey<*>>? by mutableStateOf(null)
 
     // Computed property representing the complete rich text state
     public val richString: RichString
@@ -89,6 +98,7 @@ public class RichTextState(initialText: RichString) {
 
             val cursorPosition = selection.start
             val typingAttr = typingAttributes
+            val removedAttr = removedTypingAttributes
 
             val inheritedAttributes =
                 if (cursorPosition > 0 && cursorPosition <= textFieldState.text.length) {
@@ -101,11 +111,16 @@ public class RichTextState(initialText: RichString) {
                     AttributeContainer.empty()
                 }
 
-            return if (typingAttr != null) {
-                inheritedAttributes + typingAttr
-            } else {
-                inheritedAttributes
+            var finalAttrs = inheritedAttributes
+            if (typingAttr != null) {
+                finalAttrs += typingAttr
             }
+            if (removedAttr != null) {
+                removedAttr.forEach { key ->
+                    finalAttrs -= key
+                }
+            }
+            return finalAttrs
         }
 
     /**
@@ -121,6 +136,12 @@ public class RichTextState(initialText: RichString) {
         if (!selection.collapsed) return
         val current = typingAttributes ?: AttributeContainer.empty()
         typingAttributes = current + (key to value)
+
+        val currentRemoved = removedTypingAttributes
+        if (currentRemoved != null && currentRemoved.contains(key)) {
+            val updated = currentRemoved - key
+            removedTypingAttributes = if (updated.isEmpty()) null else updated
+        }
     }
 
     /**
@@ -131,9 +152,15 @@ public class RichTextState(initialText: RichString) {
      */
     public fun <T> removeTypingAttribute(key: AttributeKey<T>) {
         if (!selection.collapsed) return
-        val current = typingAttributes ?: return
-        val updated = current - key
-        typingAttributes = if (updated.isEmpty()) null else updated
+
+        val currentTyping = typingAttributes
+        if (currentTyping != null && currentTyping.containsKey(key)) {
+            val updated = currentTyping - key
+            typingAttributes = if (updated.isEmpty()) null else updated
+        } else {
+            val currentRemoved = removedTypingAttributes ?: emptySet()
+            removedTypingAttributes = currentRemoved + key
+        }
     }
 
     /**
@@ -141,6 +168,7 @@ public class RichTextState(initialText: RichString) {
      */
     public fun clearTypingAttributes() {
         typingAttributes = null
+        removedTypingAttributes = null
     }
 
     /**
@@ -171,6 +199,7 @@ public class RichTextState(initialText: RichString) {
         }
 
         val typingAttr = typingAttributes
+        val removedAttr = removedTypingAttributes
 
         val newSpans =
             (0 until buffer.changes.changeCount).fold(spans) { currentSpans, i ->
@@ -197,6 +226,25 @@ public class RichTextState(initialText: RichString) {
                                     attributes = typingAttr,
                                 ),
                             )
+                    }
+                }
+
+                // Explicitly remove removed attributes from the inserted text
+                if (removedAttr != null && range.length > originalRange.length) {
+                    val insertStart = originalRange.min
+                    val insertEnd = insertStart + range.length - 1
+                    if (insertStart <= insertEnd) {
+                        val tempBuffer = RichTextBuffer(updatedSpans, buffer)
+                        removedAttr.forEach { key ->
+                            if (key is SpanAttributeKey<*>) {
+                                @Suppress("UNCHECKED_CAST")
+                                tempBuffer.removeSpanAttribute(key as SpanAttributeKey<Any>, insertStart..insertEnd)
+                            } else if (key is ParagraphAttributeKey<*>) {
+                                @Suppress("UNCHECKED_CAST")
+                                tempBuffer.removeParagraphAttribute(key as ParagraphAttributeKey<Any>, insertStart..insertEnd)
+                            }
+                        }
+                        updatedSpans = tempBuffer.spans
                     }
                 }
 

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -179,4 +179,77 @@ class RichTextEditorTest {
         state.currentAttributes.containsKey(BoldKey) shouldBe false
         state.currentAttributes.isEmpty() shouldBe true
     }
+
+    @Test
+    fun `turned off attributes are not inherited when typing at the end of styled text`() {
+        val initialText = "Hello"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.indices)
+                    },
+            )
+
+        composeTestRule.setContent {
+            RichTextEditor(state = state)
+        }
+
+        // Move cursor to the end of "Hello"
+        composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(initialText.length))
+
+        // At this point, currentAttributes should have BoldKey due to inheritance
+        state.currentAttributes.containsKey(BoldKey) shouldBe true
+
+        // Remove the inherited BoldKey
+        state.removeTypingAttribute(BoldKey)
+
+        // currentAttributes should no longer have BoldKey
+        state.currentAttributes.containsKey(BoldKey) shouldBe false
+
+        // Type new text
+        composeTestRule.onNodeWithText(initialText).performTextInput(" World")
+
+        // Verify that the new text does NOT have BoldKey
+        val newSpans = state.richString.spans
+        val boldSpans = newSpans.filter { it.attributes.containsKey(BoldKey) }
+
+        // Bold should only cover "Hello" (0..4)
+        boldSpans.size shouldBe 1
+        boldSpans[0].range shouldBe 0..4
+    }
+
+    @Test
+    fun `turned off attributes are not inherited when typing inside styled text`() {
+        val initialText = "Hello"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.indices)
+                    },
+            )
+
+        composeTestRule.setContent {
+            RichTextEditor(state = state)
+        }
+
+        // Move cursor to between 'l' and 'l' (index 3)
+        composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(3))
+
+        // Remove inherited BoldKey
+        state.removeTypingAttribute(BoldKey)
+
+        // Type new text
+        composeTestRule.onNodeWithText(initialText).performTextInput("x")
+
+        // The text is now "Helxlo"
+        // Bold should cover "Hel" (0..2) and "lo" (4..5), but NOT "x" (3..3)
+        val newSpans = state.richString.spans
+        val boldSpans = newSpans.filter { it.attributes.containsKey(BoldKey) }
+
+        boldSpans.size shouldBe 2
+        boldSpans[0].range shouldBe 0..2
+        boldSpans[1].range shouldBe 4..5
+    }
 }

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -167,6 +167,7 @@ class RichTextEditorTest {
 
         // Set cursor at the end
         composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(initialText.length))
+        composeTestRule.waitForIdle()
 
         // Set typing attribute
         state.setTypingAttribute(BoldKey, Unit)
@@ -174,6 +175,7 @@ class RichTextEditorTest {
 
         // Move cursor to the beginning
         composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(0))
+        composeTestRule.waitForIdle()
 
         // Typing attributes should be cleared
         state.currentAttributes.containsKey(BoldKey) shouldBe false

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -127,4 +127,56 @@ class RichTextEditorTest {
         // This guarantees `RichTextBuffer` shift logic is identical to `updateRichString`
         stateProgrammatic.richString.spans shouldBe stateUser.richString.spans
     }
+
+    @Test
+    fun `typing attributes are applied when text is entered`() {
+        val initialText = "Hello "
+        val state = RichTextState(initialText = RichString(text = initialText))
+
+        composeTestRule.setContent {
+            RichTextEditor(state = state)
+        }
+
+        // Set cursor at the end
+        composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(initialText.length))
+
+        // Set typing attribute
+        state.setTypingAttribute(BoldKey, Unit)
+
+        // Type "World"
+        composeTestRule.onNodeWithText(initialText).performTextInput("World")
+
+        val expectedNewText = "Hello World"
+        state.richString.text shouldBe expectedNewText
+
+        // Assert that the newly typed text has the Bold attribute
+        val newSpans = state.richString.spans
+        newSpans.size shouldBe 1
+        newSpans.first().range shouldBe expectedNewText.rangeOf("World")
+        newSpans.first().attributes.containsKey(BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `typing attributes are cleared on cursor movement`() {
+        val initialText = "Hello World"
+        val state = RichTextState(initialText = RichString(text = initialText))
+
+        composeTestRule.setContent {
+            RichTextEditor(state = state)
+        }
+
+        // Set cursor at the end
+        composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(initialText.length))
+
+        // Set typing attribute
+        state.setTypingAttribute(BoldKey, Unit)
+        state.currentAttributes.containsKey(BoldKey) shouldBe true
+
+        // Move cursor to the beginning
+        composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(0))
+
+        // Typing attributes should be cleared
+        state.currentAttributes.containsKey(BoldKey) shouldBe false
+        state.currentAttributes.isEmpty() shouldBe true
+    }
 }

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -1,5 +1,6 @@
 package dev.mkeeda.arranger.richtext.editor
 
+import androidx.compose.ui.text.TextRange
 import dev.mkeeda.arranger.richtext.BlockquoteKey
 import dev.mkeeda.arranger.richtext.BoldKey
 import dev.mkeeda.arranger.richtext.RichString
@@ -323,6 +324,135 @@ class RichTextStateTest {
         spans.size shouldBe 1
         spans.first().range shouldBe expectedText.rangeOf("Beautiful ")
         spans.first().attributes.containsKey(BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `currentAttributes returns attributes at cursor position`() {
+        val initialText = "Hello World"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                    },
+            )
+
+        // Cursor inside "World" (e.g., after 'W')
+        val cursorPosition = initialText.indexOf("World") + 1
+        state.textFieldState.edit {
+            selection = TextRange(cursorPosition)
+        }
+
+        val attrs = state.currentAttributes
+        attrs.containsKey(BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `currentAttributes returns empty when cursor is at position 0`() {
+        val initialText = "Hello World"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("Hello"))
+                    },
+            )
+
+        state.textFieldState.edit {
+            selection = TextRange(0)
+        }
+
+        state.currentAttributes.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `currentAttributes returns empty when text is empty`() {
+        val state = RichTextState(initialText = RichString(text = ""))
+        state.currentAttributes.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `currentAttributes returns empty when selection is not collapsed`() {
+        val initialText = "Hello World"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                    },
+            )
+
+        state.textFieldState.edit {
+            selection = TextRange(initialText.indexOf("World"), initialText.length)
+        }
+
+        state.currentAttributes.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `currentAttributes reflects typing attributes`() {
+        val initialText = "Hello World"
+        val state = RichTextState(initialText = RichString(text = initialText))
+
+        state.textFieldState.edit {
+            selection = TextRange(initialText.length)
+        }
+
+        state.setTypingAttribute(BoldKey, Unit)
+
+        val attrs = state.currentAttributes
+        attrs.containsKey(BoldKey) shouldBe true
+    }
+
+    @Test
+    fun `typing attributes override cursor attributes in currentAttributes`() {
+        val initialText = "Hello World"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                    },
+            )
+
+        // Cursor at the end of "World", where Bold is present
+        state.textFieldState.edit {
+            selection = TextRange(initialText.length)
+        }
+
+        state.currentAttributes.containsKey(BoldKey) shouldBe true
+
+        // Override with typing attribute
+        state.setTypingAttribute(BlockquoteKey, Unit) // Use a different attribute to add
+        state.setTypingAttribute(BoldKey, Unit) // Even if we set the same, it overrides
+
+        // Let's test overriding a color or something, or we can just test adding another
+        val attrs = state.currentAttributes
+        attrs.containsKey(BoldKey) shouldBe true
+        attrs.containsKey(BlockquoteKey) shouldBe true
+    }
+
+    @Test
+    fun `typing attributes can be removed`() {
+        val state = RichTextState(initialText = RichString(text = ""))
+
+        state.setTypingAttribute(BoldKey, Unit)
+        state.currentAttributes.containsKey(BoldKey) shouldBe true
+
+        state.removeTypingAttribute(BoldKey)
+        state.currentAttributes.containsKey(BoldKey) shouldBe false
+        state.currentAttributes.isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `typing attributes can be cleared`() {
+        val state = RichTextState(initialText = RichString(text = ""))
+
+        state.setTypingAttribute(BoldKey, Unit)
+        state.setTypingAttribute(BlockquoteKey, Unit)
+
+        state.clearTypingAttributes()
+        state.currentAttributes.isEmpty() shouldBe true
     }
 }
 

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -3,7 +3,11 @@ package dev.mkeeda.arranger.richtext.editor
 import androidx.compose.ui.text.TextRange
 import dev.mkeeda.arranger.richtext.BlockquoteKey
 import dev.mkeeda.arranger.richtext.BoldKey
+import dev.mkeeda.arranger.richtext.ItalicKey
+import dev.mkeeda.arranger.richtext.RgbaColor
 import dev.mkeeda.arranger.richtext.RichString
+import dev.mkeeda.arranger.richtext.TextColorKey
+import dev.mkeeda.arranger.richtext.attributeContainerOf
 import dev.mkeeda.arranger.richtext.rangeOf
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -344,7 +348,7 @@ class RichTextStateTest {
         }
 
         val attrs = state.currentAttributes
-        attrs.containsKey(BoldKey) shouldBe true
+        attrs shouldBe attributeContainerOf(BoldKey to Unit)
     }
 
     @Test
@@ -362,31 +366,35 @@ class RichTextStateTest {
             selection = TextRange(0)
         }
 
-        state.currentAttributes.isEmpty() shouldBe true
+        state.currentAttributes shouldBe attributeContainerOf()
     }
 
     @Test
     fun `currentAttributes returns empty when text is empty`() {
         val state = RichTextState(initialText = RichString(text = ""))
-        state.currentAttributes.isEmpty() shouldBe true
+        state.currentAttributes shouldBe attributeContainerOf()
     }
 
     @Test
-    fun `currentAttributes returns empty when selection is not collapsed`() {
+    fun `currentAttributes returns intersection of attributes when selection is not collapsed`() {
         val initialText = "Hello World"
         val state =
             RichTextState(
                 initialText =
                     RichString(text = initialText).edit {
-                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("World"))
+                        // "Hello " is Bold, "World" is Bold and Italic
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("Hello World"))
+                        setSpanAttribute(ItalicKey, Unit, range = initialText.rangeOf("World"))
                     },
             )
 
+        // Select "lo Wo"
         state.textFieldState.edit {
-            selection = TextRange(initialText.indexOf("World"), initialText.length)
+            selection = TextRange(initialText.indexOf("lo"), initialText.indexOf("rld"))
         }
 
-        state.currentAttributes.isEmpty() shouldBe true
+        // Only Bold is common across the entire selection
+        state.currentAttributes shouldBe attributeContainerOf(BoldKey to Unit)
     }
 
     @Test
@@ -401,7 +409,7 @@ class RichTextStateTest {
         state.setTypingAttribute(BoldKey, Unit)
 
         val attrs = state.currentAttributes
-        attrs.containsKey(BoldKey) shouldBe true
+        attrs shouldBe attributeContainerOf(BoldKey to Unit)
     }
 
     @Test
@@ -423,13 +431,15 @@ class RichTextStateTest {
         state.currentAttributes.containsKey(BoldKey) shouldBe true
 
         // Override with typing attribute
-        state.setTypingAttribute(BlockquoteKey, Unit) // Use a different attribute to add
-        state.setTypingAttribute(BoldKey, Unit) // Even if we set the same, it overrides
+        val newColor = RgbaColor(0xFFFF0000)
+        state.setTypingAttribute(TextColorKey, newColor)
 
-        // Let's test overriding a color or something, or we can just test adding another
         val attrs = state.currentAttributes
-        attrs.containsKey(BoldKey) shouldBe true
-        attrs.containsKey(BlockquoteKey) shouldBe true
+        attrs shouldBe
+            attributeContainerOf(
+                BoldKey to Unit,
+                TextColorKey to newColor,
+            )
     }
 
     @Test
@@ -440,8 +450,7 @@ class RichTextStateTest {
         state.currentAttributes.containsKey(BoldKey) shouldBe true
 
         state.removeTypingAttribute(BoldKey)
-        state.currentAttributes.containsKey(BoldKey) shouldBe false
-        state.currentAttributes.isEmpty() shouldBe true
+        state.currentAttributes shouldBe attributeContainerOf()
     }
 
     @Test
@@ -452,7 +461,7 @@ class RichTextStateTest {
         state.setTypingAttribute(BlockquoteKey, Unit)
 
         state.clearTypingAttributes()
-        state.currentAttributes.isEmpty() shouldBe true
+        state.currentAttributes shouldBe attributeContainerOf()
     }
 }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScope.kt
@@ -36,6 +36,14 @@ public class AttributeEditScope internal constructor(
             buffer.setParagraphAttribute(key, value, range)
         }
     }
+
+    /**
+     * Removes all rich text attributes (both span and paragraph level) in the range.
+     * Including user-customized attributes.
+     */
+    public fun clearAll() {
+        buffer.clearAllAttributes(range)
+    }
 }
 
 /**

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
@@ -82,6 +82,27 @@ public class RichStringScope
         }
 
         /**
+         * Removes all attributes (both span and paragraph level) within the given [range].
+         * Paragraph attributes will be cleared from their entire respective paragraphs.
+         */
+        public fun clearAllAttributes(range: IntRange = 0 until textLength) {
+            checkRange(range)
+
+            // Clear span attributes exactly in the specified range by keeping only paragraph attributes
+            currentSpans =
+                currentSpans.transformSpans(targetRange = range) { attributes ->
+                    attributes.filterParagraphAttributes()
+                }
+
+            // Clear paragraph attributes in the snapped paragraph boundaries by keeping only span attributes
+            val snappedRange = range.snapToParagraphs(text)
+            currentSpans =
+                currentSpans.transformSpans(targetRange = snappedRange) { attributes ->
+                    attributes.filterSpanAttributes()
+                }
+        }
+
+        /**
          * Applies a set of attribute mutations to the specified [range] using a DSL builder.
          */
         public fun editAttributes(

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichStringScope.kt
@@ -142,7 +142,9 @@ public class RichStringScope
         }
 
         private fun checkRange(range: IntRange) {
-            require(!range.isEmpty()) { "Range must not be empty: $range" }
+            // Empty ranges (where first = last + 1) represent a collapsed cursor position.
+            // Span attributes gracefully ignore empty target ranges, while paragraph attributes
+            // use the cursor position to snap to the surrounding paragraph bounds.
             require(range.first >= 0) { "Range start must not be negative: ${range.first}" }
             require(range.last < textLength) { "Range end must be within text bounds: ${range.last} >= $textLength" }
         }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/SpanMerger.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/SpanMerger.kt
@@ -106,7 +106,8 @@ internal fun List<RichSpan>.transformSpans(
  * Merges a [newSpan] into this list of spans.
  * Convenience extension that wraps [transformSpans].
  */
-internal fun List<RichSpan>.mergeSpan(newSpan: RichSpan): List<RichSpan> {
+@InternalArrangerApi
+public fun List<RichSpan>.mergeSpan(newSpan: RichSpan): List<RichSpan> {
     return transformSpans(targetRange = newSpan.range) { existingAttributes ->
         existingAttributes + newSpan.attributes
     }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/SpanMerger.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/SpanMerger.kt
@@ -105,6 +105,10 @@ internal fun List<RichSpan>.transformSpans(
 /**
  * Merges a [newSpan] into this list of spans.
  * Convenience extension that wraps [transformSpans].
+ *
+ * Note: This function is public to allow cross-module usage within the library
+ * (e.g., from the `richtext-editor` module), but is marked with `@InternalArrangerApi`
+ * as it is not intended to be a stable public API for library consumers.
  */
 @InternalArrangerApi
 public fun List<RichSpan>.mergeSpan(newSpan: RichSpan): List<RichSpan> {

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScopeTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScopeTest.kt
@@ -202,4 +202,29 @@ class AttributeEditScopeTest {
             }
         str.spans.isEmpty() shouldBe true
     }
+
+    @Test
+    fun `clearAll removes all known attributes properly`() {
+        var str =
+            RichString("Test").edit {
+                editAttributes {
+                    textColor(RgbaColor(0xFFFF0000))
+                    bold()
+                    italic()
+                    strikethrough()
+                    underline()
+                    headingLevel(HeadingLevel.H1)
+                    bulletList(ListIndentLevel.Level1)
+                }
+            }
+
+        str.spans.isEmpty() shouldBe false
+
+        str =
+            str.edit {
+                editAttributes { clearAll() }
+            }
+
+        str.spans.isEmpty() shouldBe true
+    }
 }

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditSpanTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditSpanTest.kt
@@ -90,13 +90,12 @@ class RichStringEditSpanTest {
     }
 
     @Test
-    fun `throws IllegalArgumentException when range is reversed or empty`() {
-        val richString = RichString(text = "Hello, World!")
-        val exception =
-            shouldThrow<IllegalArgumentException> {
-                richString.edit { setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 5..3) }
-            }
-        exception.message shouldBe "Range must not be empty: 5..3"
+    fun `safely ignores when applying to a reversed or empty range`() {
+        val original = RichString(text = "Hello, World!")
+        val richString = original.edit { setSpanAttribute(TextColorKey, RgbaColor(0xFFFF0000), range = 5..3) }
+
+        richString.spans.shouldBeEmpty()
+        richString.text shouldBe original.text
     }
 
     @Test

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
@@ -144,31 +144,54 @@ private fun ChatFormattingToolbar(
     ) {
         val formatActions =
             listOf(
-                FormatAction(R.drawable.format_bold, "Bold", BoldKey, Unit) { bold() },
-                FormatAction(R.drawable.format_italic, "Italic", ItalicKey, Unit) { italic() },
-                FormatAction(R.drawable.format_underlined, "Underline", UnderlineKey, Unit) { underline() },
-                FormatAction(R.drawable.format_strikethrough, "Strikethrough", StrikethroughKey, Unit) { strikethrough() },
-                FormatAction(R.drawable.format_color_text, "Text Color Red", TextColorKey, RgbaColor(0xFFFF0000.toLong())) {
+                FormatAction(R.drawable.format_bold, "Bold", BoldKey, Unit, { bold() }, { clearBold() }),
+                FormatAction(R.drawable.format_italic, "Italic", ItalicKey, Unit, { italic() }, { clearItalic() }),
+                FormatAction(R.drawable.format_underlined, "Underline", UnderlineKey, Unit, { underline() }, { clearUnderline() }),
+                FormatAction(
+                    R.drawable.format_strikethrough,
+                    "Strikethrough",
+                    StrikethroughKey,
+                    Unit,
+                    { strikethrough() },
+                    { clearStrikethrough() },
+                ),
+                FormatAction(R.drawable.format_color_text, "Text Color Red", TextColorKey, RgbaColor(0xFFFF0000.toLong()), {
                     textColor(RgbaColor(0xFFFF0000.toLong()))
-                },
-                FormatAction(R.drawable.format_color_fill, "Background Color Yellow", BackgroundColorKey, RgbaColor(0xFFFFFF00.toLong())) {
+                }, { clearTextColor() }),
+                FormatAction(R.drawable.format_color_fill, "Background Color Yellow", BackgroundColorKey, RgbaColor(0xFFFFFF00.toLong()), {
                     backgroundColor(RgbaColor(0xFFFFFF00.toLong()))
-                },
-                FormatAction(R.drawable.format_size, "Large Font Size", FontSizeKey, TextSize(24f)) { fontSize(TextSize(24f)) },
-                FormatAction(R.drawable.format_h1, "Heading 1", HeadingKey, HeadingLevel.H1) { headingLevel(HeadingLevel.H1) },
-                FormatAction(R.drawable.format_align_center, "Align Center", TextAlignmentKey, TextAlignment.Center) {
+                }, { clearBackgroundColor() }),
+                FormatAction(
+                    R.drawable.format_size,
+                    "Large Font Size",
+                    FontSizeKey,
+                    TextSize(24f),
+                    { fontSize(TextSize(24f)) },
+                    { clearFontSize() },
+                ),
+                FormatAction(
+                    R.drawable.format_h1,
+                    "Heading 1",
+                    HeadingKey,
+                    HeadingLevel.H1,
+                    { headingLevel(HeadingLevel.H1) },
+                    { clearHeadingLevel() },
+                ),
+                FormatAction(R.drawable.format_align_center, "Align Center", TextAlignmentKey, TextAlignment.Center, {
                     textAlignment(TextAlignment.Center)
-                },
-                FormatAction(R.drawable.format_quote, "Blockquote", BlockquoteKey, Unit) { blockquote() },
+                }, { clearTextAlignment() }),
+                FormatAction(R.drawable.format_quote, "Blockquote", BlockquoteKey, Unit, { blockquote() }, { clearBlockquote() }),
                 FormatAction(
                     R.drawable.format_list_bulleted,
                     "Bullet List",
                     BulletListKey,
                     ListIndentLevel.Level1,
-                ) { bulletList(ListIndentLevel.Level1) },
-                FormatAction(R.drawable.format_list_numbered, "Ordered List", OrderedListKey, ListIndentLevel.Level1) {
+                    { bulletList(ListIndentLevel.Level1) },
+                    { clearBulletList() },
+                ),
+                FormatAction(R.drawable.format_list_numbered, "Ordered List", OrderedListKey, ListIndentLevel.Level1, {
                     orderedList(ListIndentLevel.Level1)
-                },
+                }, { clearOrderedList() }),
             )
 
         formatActions.forEach { action ->
@@ -177,7 +200,15 @@ private fun ChatFormattingToolbar(
                 checked = isActive,
                 onCheckedChange = {
                     if (hasSelection) {
-                        state.edit { editAttributes(state.selection) { action.applySelection(this) } }
+                        state.edit {
+                            editAttributes(state.selection) {
+                                if (isActive) {
+                                    action.removeSelection(this)
+                                } else {
+                                    action.applySelection(this)
+                                }
+                            }
+                        }
                     } else {
                         toggleTypingAttribute(state, action, isActive)
                     }
@@ -249,6 +280,7 @@ private data class FormatAction<T : Any>(
     val key: AttributeKey<T>,
     val value: T,
     val applySelection: AttributeEditScope.() -> Unit,
+    val removeSelection: AttributeEditScope.() -> Unit,
 )
 
 @Composable

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,12 +32,25 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.mkeeda.arranger.richtext.AttributeEditScope
+import dev.mkeeda.arranger.richtext.AttributeKey
+import dev.mkeeda.arranger.richtext.BackgroundColorKey
+import dev.mkeeda.arranger.richtext.BlockquoteKey
+import dev.mkeeda.arranger.richtext.BoldKey
+import dev.mkeeda.arranger.richtext.BulletListKey
+import dev.mkeeda.arranger.richtext.FontSizeKey
+import dev.mkeeda.arranger.richtext.HeadingKey
 import dev.mkeeda.arranger.richtext.HeadingLevel
+import dev.mkeeda.arranger.richtext.ItalicKey
 import dev.mkeeda.arranger.richtext.ListIndentLevel
+import dev.mkeeda.arranger.richtext.OrderedListKey
 import dev.mkeeda.arranger.richtext.RgbaColor
 import dev.mkeeda.arranger.richtext.RichString
+import dev.mkeeda.arranger.richtext.StrikethroughKey
 import dev.mkeeda.arranger.richtext.TextAlignment
+import dev.mkeeda.arranger.richtext.TextAlignmentKey
+import dev.mkeeda.arranger.richtext.TextColorKey
 import dev.mkeeda.arranger.richtext.TextSize
+import dev.mkeeda.arranger.richtext.UnderlineKey
 import dev.mkeeda.arranger.richtext.backgroundColor
 import dev.mkeeda.arranger.richtext.blockquote
 import dev.mkeeda.arranger.richtext.bold
@@ -76,7 +91,7 @@ fun ChatInputSample(modifier: Modifier = Modifier) {
                 .imePadding(),
     ) {
         Text(
-            text = "Select text and use the toolbar to format it. Real-time cursor state reflection is not supported in this phase.",
+            text = "Select text and use the toolbar to format it, or use the toolbar before typing.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -129,24 +144,50 @@ private fun ChatFormattingToolbar(
     ) {
         val formatActions =
             listOf(
-                FormatAction(R.drawable.format_bold, "Bold") { bold() },
-                FormatAction(R.drawable.format_italic, "Italic") { italic() },
-                FormatAction(R.drawable.format_underlined, "Underline") { underline() },
-                FormatAction(R.drawable.format_strikethrough, "Strikethrough") { strikethrough() },
-                FormatAction(R.drawable.format_color_text, "Text Color Red") { textColor(RgbaColor(0xFFFF0000.toLong())) },
-                FormatAction(R.drawable.format_color_fill, "Background Color Yellow") { backgroundColor(RgbaColor(0xFFFFFF00.toLong())) },
-                FormatAction(R.drawable.format_size, "Large Font Size") { fontSize(TextSize(24f)) },
-                FormatAction(R.drawable.format_h1, "Heading 1") { headingLevel(HeadingLevel.H1) },
-                FormatAction(R.drawable.format_align_center, "Align Center") { textAlignment(TextAlignment.Center) },
-                FormatAction(R.drawable.format_quote, "Blockquote") { blockquote() },
-                FormatAction(R.drawable.format_list_bulleted, "Bullet List") { bulletList(ListIndentLevel.Level1) },
-                FormatAction(R.drawable.format_list_numbered, "Ordered List") { orderedList(ListIndentLevel.Level1) },
+                FormatAction(R.drawable.format_bold, "Bold", BoldKey, Unit) { bold() },
+                FormatAction(R.drawable.format_italic, "Italic", ItalicKey, Unit) { italic() },
+                FormatAction(R.drawable.format_underlined, "Underline", UnderlineKey, Unit) { underline() },
+                FormatAction(R.drawable.format_strikethrough, "Strikethrough", StrikethroughKey, Unit) { strikethrough() },
+                FormatAction(R.drawable.format_color_text, "Text Color Red", TextColorKey, RgbaColor(0xFFFF0000.toLong())) {
+                    textColor(RgbaColor(0xFFFF0000.toLong()))
+                },
+                FormatAction(R.drawable.format_color_fill, "Background Color Yellow", BackgroundColorKey, RgbaColor(0xFFFFFF00.toLong())) {
+                    backgroundColor(RgbaColor(0xFFFFFF00.toLong()))
+                },
+                FormatAction(R.drawable.format_size, "Large Font Size", FontSizeKey, TextSize(24f)) { fontSize(TextSize(24f)) },
+                FormatAction(R.drawable.format_h1, "Heading 1", HeadingKey, HeadingLevel.H1) { headingLevel(HeadingLevel.H1) },
+                FormatAction(R.drawable.format_align_center, "Align Center", TextAlignmentKey, TextAlignment.Center) {
+                    textAlignment(TextAlignment.Center)
+                },
+                FormatAction(R.drawable.format_quote, "Blockquote", BlockquoteKey, Unit) { blockquote() },
+                FormatAction(
+                    R.drawable.format_list_bulleted,
+                    "Bullet List",
+                    BulletListKey,
+                    ListIndentLevel.Level1,
+                ) { bulletList(ListIndentLevel.Level1) },
+                FormatAction(R.drawable.format_list_numbered, "Ordered List", OrderedListKey, ListIndentLevel.Level1) {
+                    orderedList(ListIndentLevel.Level1)
+                },
             )
 
         formatActions.forEach { action ->
-            IconButton(
-                onClick = { state.edit { editAttributes(state.selection) { action.action(this) } } },
-                enabled = hasSelection,
+            val isActive = state.currentAttributes.containsKey(action.key)
+            IconToggleButton(
+                checked = isActive,
+                onCheckedChange = {
+                    if (hasSelection) {
+                        state.edit { editAttributes(state.selection) { action.applySelection(this) } }
+                    } else {
+                        toggleTypingAttribute(state, action, isActive)
+                    }
+                },
+                enabled = true,
+                colors =
+                    IconButtonDefaults.iconToggleButtonColors(
+                        checkedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        checkedContentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ),
             ) {
                 Icon(
                     painter = painterResource(id = action.iconRes),
@@ -159,24 +200,28 @@ private fun ChatFormattingToolbar(
 
         IconButton(
             onClick = {
-                state.edit {
-                    editAttributes(state.selection) {
-                        clearBold()
-                        clearItalic()
-                        clearStrikethrough()
-                        clearUnderline()
-                        clearTextColor()
-                        clearBackgroundColor()
-                        clearFontSize()
-                        clearHeadingLevel()
-                        clearTextAlignment()
-                        clearBlockquote()
-                        clearBulletList()
-                        clearOrderedList()
+                if (hasSelection) {
+                    state.edit {
+                        editAttributes(state.selection) {
+                            clearBold()
+                            clearItalic()
+                            clearStrikethrough()
+                            clearUnderline()
+                            clearTextColor()
+                            clearBackgroundColor()
+                            clearFontSize()
+                            clearHeadingLevel()
+                            clearTextAlignment()
+                            clearBlockquote()
+                            clearBulletList()
+                            clearOrderedList()
+                        }
                     }
+                } else {
+                    state.clearTypingAttributes()
                 }
             },
-            enabled = hasSelection,
+            enabled = true,
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.format_clear),
@@ -186,10 +231,24 @@ private fun ChatFormattingToolbar(
     }
 }
 
-private data class FormatAction(
+private fun <T : Any> toggleTypingAttribute(
+    state: RichTextState,
+    action: FormatAction<T>,
+    isActive: Boolean,
+) {
+    if (isActive) {
+        state.removeTypingAttribute(action.key)
+    } else {
+        state.setTypingAttribute(action.key, action.value)
+    }
+}
+
+private data class FormatAction<T : Any>(
     @DrawableRes val iconRes: Int,
     val contentDescription: String,
-    val action: AttributeEditScope.() -> Unit,
+    val key: AttributeKey<T>,
+    val value: T,
+    val applySelection: AttributeEditScope.() -> Unit,
 )
 
 @Composable

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
@@ -256,18 +256,7 @@ private fun ChatFormattingToolbar(
                 if (hasSelection) {
                     state.edit {
                         editAttributes(state.selection) {
-                            clearBold()
-                            clearItalic()
-                            clearStrikethrough()
-                            clearUnderline()
-                            clearTextColor()
-                            clearBackgroundColor()
-                            clearFontSize()
-                            clearHeadingLevel()
-                            clearTextAlignment()
-                            clearBlockquote()
-                            clearBulletList()
-                            clearOrderedList()
+                            clearAll()
                         }
                     }
                 } else {

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
@@ -43,8 +43,10 @@ import dev.mkeeda.arranger.richtext.HeadingLevel
 import dev.mkeeda.arranger.richtext.ItalicKey
 import dev.mkeeda.arranger.richtext.ListIndentLevel
 import dev.mkeeda.arranger.richtext.OrderedListKey
+import dev.mkeeda.arranger.richtext.ParagraphAttributeKey
 import dev.mkeeda.arranger.richtext.RgbaColor
 import dev.mkeeda.arranger.richtext.RichString
+import dev.mkeeda.arranger.richtext.SpanAttributeKey
 import dev.mkeeda.arranger.richtext.StrikethroughKey
 import dev.mkeeda.arranger.richtext.TextAlignment
 import dev.mkeeda.arranger.richtext.TextAlignmentKey
@@ -144,54 +146,78 @@ private fun ChatFormattingToolbar(
     ) {
         val formatActions =
             listOf(
-                FormatAction(R.drawable.format_bold, "Bold", BoldKey, Unit, { bold() }, { clearBold() }),
-                FormatAction(R.drawable.format_italic, "Italic", ItalicKey, Unit, { italic() }, { clearItalic() }),
-                FormatAction(R.drawable.format_underlined, "Underline", UnderlineKey, Unit, { underline() }, { clearUnderline() }),
-                FormatAction(
-                    R.drawable.format_strikethrough,
-                    "Strikethrough",
-                    StrikethroughKey,
-                    Unit,
-                    { strikethrough() },
-                    { clearStrikethrough() },
+                FormatAction.Span(
+                    iconRes = R.drawable.format_bold,
+                    contentDescription = "Bold",
+                    key = BoldKey,
+                    value = Unit,
                 ),
-                FormatAction(R.drawable.format_color_text, "Text Color Red", TextColorKey, RgbaColor(0xFFFF0000.toLong()), {
-                    textColor(RgbaColor(0xFFFF0000.toLong()))
-                }, { clearTextColor() }),
-                FormatAction(R.drawable.format_color_fill, "Background Color Yellow", BackgroundColorKey, RgbaColor(0xFFFFFF00.toLong()), {
-                    backgroundColor(RgbaColor(0xFFFFFF00.toLong()))
-                }, { clearBackgroundColor() }),
-                FormatAction(
-                    R.drawable.format_size,
-                    "Large Font Size",
-                    FontSizeKey,
-                    TextSize(24f),
-                    { fontSize(TextSize(24f)) },
-                    { clearFontSize() },
+                FormatAction.Span(
+                    iconRes = R.drawable.format_italic,
+                    contentDescription = "Italic",
+                    key = ItalicKey,
+                    value = Unit,
                 ),
-                FormatAction(
-                    R.drawable.format_h1,
-                    "Heading 1",
-                    HeadingKey,
-                    HeadingLevel.H1,
-                    { headingLevel(HeadingLevel.H1) },
-                    { clearHeadingLevel() },
+                FormatAction.Span(
+                    iconRes = R.drawable.format_underlined,
+                    contentDescription = "Underline",
+                    key = UnderlineKey,
+                    value = Unit,
                 ),
-                FormatAction(R.drawable.format_align_center, "Align Center", TextAlignmentKey, TextAlignment.Center, {
-                    textAlignment(TextAlignment.Center)
-                }, { clearTextAlignment() }),
-                FormatAction(R.drawable.format_quote, "Blockquote", BlockquoteKey, Unit, { blockquote() }, { clearBlockquote() }),
-                FormatAction(
-                    R.drawable.format_list_bulleted,
-                    "Bullet List",
-                    BulletListKey,
-                    ListIndentLevel.Level1,
-                    { bulletList(ListIndentLevel.Level1) },
-                    { clearBulletList() },
+                FormatAction.Span(
+                    iconRes = R.drawable.format_strikethrough,
+                    contentDescription = "Strikethrough",
+                    key = StrikethroughKey,
+                    value = Unit,
                 ),
-                FormatAction(R.drawable.format_list_numbered, "Ordered List", OrderedListKey, ListIndentLevel.Level1, {
-                    orderedList(ListIndentLevel.Level1)
-                }, { clearOrderedList() }),
+                FormatAction.Span(
+                    iconRes = R.drawable.format_color_text,
+                    contentDescription = "Text Color Red",
+                    key = TextColorKey,
+                    value = RgbaColor(0xFFFF0000.toLong()),
+                ),
+                FormatAction.Span(
+                    iconRes = R.drawable.format_color_fill,
+                    contentDescription = "Background Color Yellow",
+                    key = BackgroundColorKey,
+                    value = RgbaColor(0xFFFFFF00.toLong()),
+                ),
+                FormatAction.Span(
+                    iconRes = R.drawable.format_size,
+                    contentDescription = "Large Font Size",
+                    key = FontSizeKey,
+                    value = TextSize(24f),
+                ),
+                FormatAction.Paragraph(
+                    iconRes = R.drawable.format_h1,
+                    contentDescription = "Heading 1",
+                    key = HeadingKey,
+                    value = HeadingLevel.H1,
+                ),
+                FormatAction.Paragraph(
+                    iconRes = R.drawable.format_align_center,
+                    contentDescription = "Align Center",
+                    key = TextAlignmentKey,
+                    value = TextAlignment.Center,
+                ),
+                FormatAction.Paragraph(
+                    iconRes = R.drawable.format_quote,
+                    contentDescription = "Blockquote",
+                    key = BlockquoteKey,
+                    value = Unit,
+                ),
+                FormatAction.Paragraph(
+                    iconRes = R.drawable.format_list_bulleted,
+                    contentDescription = "Bullet List",
+                    key = BulletListKey,
+                    value = ListIndentLevel.Level1,
+                ),
+                FormatAction.Paragraph(
+                    iconRes = R.drawable.format_list_numbered,
+                    contentDescription = "Ordered List",
+                    key = OrderedListKey,
+                    value = ListIndentLevel.Level1,
+                ),
             )
 
         formatActions.forEach { action ->
@@ -202,15 +228,11 @@ private fun ChatFormattingToolbar(
                     if (hasSelection) {
                         state.edit {
                             editAttributes(state.selection) {
-                                if (isActive) {
-                                    action.removeSelection(this)
-                                } else {
-                                    action.applySelection(this)
-                                }
+                                action.applyAttribute(this, isActive)
                             }
                         }
                     } else {
-                        toggleTypingAttribute(state, action, isActive)
+                        action.toggleTyping(state, isActive)
                     }
                 },
                 enabled = true,
@@ -262,26 +284,45 @@ private fun ChatFormattingToolbar(
     }
 }
 
-private fun <T : Any> toggleTypingAttribute(
-    state: RichTextState,
-    action: FormatAction<T>,
-    isActive: Boolean,
-) {
-    if (isActive) {
-        state.removeTypingAttribute(action.key)
-    } else {
-        state.setTypingAttribute(action.key, action.value)
+private sealed interface FormatAction<T : Any> {
+    val iconRes: Int
+    val contentDescription: String
+    val key: AttributeKey<T>
+
+    fun applyAttribute(scope: AttributeEditScope, isActive: Boolean)
+
+    fun toggleTyping(state: RichTextState, isActive: Boolean)
+
+    data class Span<T : Any>(
+        @DrawableRes override val iconRes: Int,
+        override val contentDescription: String,
+        override val key: SpanAttributeKey<T>,
+        val value: T,
+    ) : FormatAction<T> {
+        override fun applyAttribute(scope: AttributeEditScope, isActive: Boolean) {
+            scope.setSpanAttribute(key, if (isActive) null else value)
+        }
+
+        override fun toggleTyping(state: RichTextState, isActive: Boolean) {
+            if (isActive) state.removeTypingAttribute(key) else state.setTypingAttribute(key, value)
+        }
+    }
+
+    data class Paragraph<T : Any>(
+        @DrawableRes override val iconRes: Int,
+        override val contentDescription: String,
+        override val key: ParagraphAttributeKey<T>,
+        val value: T,
+    ) : FormatAction<T> {
+        override fun applyAttribute(scope: AttributeEditScope, isActive: Boolean) {
+            scope.setParagraphAttribute(key, if (isActive) null else value)
+        }
+
+        override fun toggleTyping(state: RichTextState, isActive: Boolean) {
+            if (isActive) state.removeTypingAttribute(key) else state.setTypingAttribute(key, value)
+        }
     }
 }
-
-private data class FormatAction<T : Any>(
-    @DrawableRes val iconRes: Int,
-    val contentDescription: String,
-    val key: AttributeKey<T>,
-    val value: T,
-    val applySelection: AttributeEditScope.() -> Unit,
-    val removeSelection: AttributeEditScope.() -> Unit,
-)
 
 @Composable
 private fun ChatInputField(state: RichTextState, modifier: Modifier = Modifier) {

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
@@ -308,7 +308,7 @@ private sealed interface FormatAction<T : Any> {
         }
 
         override fun toggleTyping(state: RichTextState, isActive: Boolean) {
-            // Paragraph attributes logcially apply to the whole paragraph immediately.
+            // Paragraph attributes logically apply to the whole paragraph immediately.
             // There's no need to delay it as a typing attribute.
             state.edit {
                 editAttributes(state.selection) {

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
@@ -319,7 +319,13 @@ private sealed interface FormatAction<T : Any> {
         }
 
         override fun toggleTyping(state: RichTextState, isActive: Boolean) {
-            if (isActive) state.removeTypingAttribute(key) else state.setTypingAttribute(key, value)
+            // Paragraph attributes logcially apply to the whole paragraph immediately.
+            // There's no need to delay it as a typing attribute.
+            state.edit {
+                editAttributes(state.selection) {
+                    applyAttribute(this, isActive)
+                }
+            }
         }
     }
 }

--- a/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
+++ b/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
@@ -2,11 +2,13 @@ package dev.mkeeda.arranger.sampleApp
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextInputSelection
 import androidx.compose.ui.text.TextRange
@@ -48,12 +50,12 @@ class ChatInputSampleTest {
         // Check if placeholder is displayed
         composeTestRule.onNodeWithText("Type a message...").assertIsDisplayed()
 
-        // Buttons should be disabled initially (no selection)
-        composeTestRule.onNodeWithContentDescription("Bold").assertIsNotEnabled()
+        // Buttons should be enabled initially (even with no selection)
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsEnabled()
     }
 
     @Test
-    fun `buttons are enabled only when text is selected`() {
+    fun `buttons are always enabled regardless of selection`() {
         composeTestRule.setContent {
             ArrangerTheme {
                 ChatInputSample()
@@ -63,13 +65,70 @@ class ChatInputSampleTest {
         val textInputNode = composeTestRule.onNodeWithTag("ChatInputEditor")
         textInputNode.performTextInput("Hello World")
 
-        // Still disabled because no text is selected (selection is just a cursor)
-        composeTestRule.onNodeWithContentDescription("Bold").assertIsNotEnabled()
+        // Enabled even with no selection (cursor only)
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsEnabled()
 
         // Select some text
         textInputNode.performTextInputSelection(TextRange(0, 5))
 
-        // Now buttons should be enabled
+        // Still enabled
         composeTestRule.onNodeWithContentDescription("Bold").assertIsEnabled()
+    }
+
+    @Test
+    fun `toolbar buttons sync with cursor position attributes`() {
+        composeTestRule.setContent {
+            ArrangerTheme {
+                ChatInputSample()
+            }
+        }
+
+        val textInputNode = composeTestRule.onNodeWithTag("ChatInputEditor")
+        textInputNode.performTextInput("Hello World")
+
+        // Select "Hello" and apply Bold
+        textInputNode.performTextInputSelection(TextRange(0, 5))
+        composeTestRule.onNodeWithContentDescription("Bold").performClick()
+
+        // Move cursor to "Hello" (index 3)
+        textInputNode.performTextInputSelection(TextRange(3))
+
+        // Bold button should be toggled ON
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOn()
+
+        // Move cursor to "World" (index 8)
+        textInputNode.performTextInputSelection(TextRange(8))
+
+        // Bold button should be toggled OFF
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOff()
+    }
+
+    @Test
+    fun `typing attributes toggle on collapsed selection`() {
+        composeTestRule.setContent {
+            ArrangerTheme {
+                ChatInputSample()
+            }
+        }
+
+        val textInputNode = composeTestRule.onNodeWithTag("ChatInputEditor")
+
+        // Tap Bold button when empty
+        composeTestRule.onNodeWithContentDescription("Bold").performClick()
+
+        // Button should be toggled ON
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOn()
+
+        // Type text
+        textInputNode.performTextInput("BoldText")
+
+        // Cursor is now at the end of "BoldText", which is bold, so button should remain ON
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOn()
+
+        // Move cursor to beginning (index 0)
+        textInputNode.performTextInputSelection(TextRange(0))
+
+        // Button should be OFF because at index 0, there is no inherited attribute and no typing attribute
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOff()
     }
 }

--- a/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
+++ b/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
@@ -24,58 +24,6 @@ class ChatInputSampleTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun `initial state shows empty editor and formatting buttons`() {
-        composeTestRule.setContent {
-            ArrangerTheme {
-                ChatInputSample()
-            }
-        }
-
-        // Check if toolbar buttons exist in the composition (some may be scrolled off-screen)
-        composeTestRule.onNodeWithContentDescription("Bold").assertExists()
-        composeTestRule.onNodeWithContentDescription("Italic").assertExists()
-        composeTestRule.onNodeWithContentDescription("Strikethrough").assertExists()
-        composeTestRule.onNodeWithContentDescription("Underline").assertExists()
-        composeTestRule.onNodeWithContentDescription("Text Color Red").assertExists()
-        composeTestRule.onNodeWithContentDescription("Background Color Yellow").assertExists()
-        composeTestRule.onNodeWithContentDescription("Large Font Size").assertExists()
-        composeTestRule.onNodeWithContentDescription("Heading 1").assertExists()
-        composeTestRule.onNodeWithContentDescription("Align Center").assertExists()
-        composeTestRule.onNodeWithContentDescription("Blockquote").assertExists()
-        composeTestRule.onNodeWithContentDescription("Clear Formatting").assertExists()
-
-        // Check if the editor exists by tag
-        composeTestRule.onNodeWithTag("ChatInputEditor").assertIsDisplayed()
-
-        // Check if placeholder is displayed
-        composeTestRule.onNodeWithText("Type a message...").assertIsDisplayed()
-
-        // Buttons should be enabled initially (even with no selection)
-        composeTestRule.onNodeWithContentDescription("Bold").assertIsEnabled()
-    }
-
-    @Test
-    fun `buttons are always enabled regardless of selection`() {
-        composeTestRule.setContent {
-            ArrangerTheme {
-                ChatInputSample()
-            }
-        }
-
-        val textInputNode = composeTestRule.onNodeWithTag("ChatInputEditor")
-        textInputNode.performTextInput("Hello World")
-
-        // Enabled even with no selection (cursor only)
-        composeTestRule.onNodeWithContentDescription("Bold").assertIsEnabled()
-
-        // Select some text
-        textInputNode.performTextInputSelection(TextRange(0, 5))
-
-        // Still enabled
-        composeTestRule.onNodeWithContentDescription("Bold").assertIsEnabled()
-    }
-
-    @Test
     fun `toolbar buttons sync with cursor position attributes`() {
         composeTestRule.setContent {
             ArrangerTheme {

--- a/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
+++ b/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
@@ -96,6 +96,16 @@ class ChatInputSampleTest {
         // Cursor is now at the end of "BoldText", which is bold, so button should remain ON
         composeTestRule.onNodeWithContentDescription("Bold").assertIsOn()
 
+        // Turn OFF Bold at the current position
+        composeTestRule.onNodeWithContentDescription("Bold").performClick()
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOff()
+
+        // Type more text
+        textInputNode.performTextInput("Normal")
+
+        // Cursor is now at the end of "Normal", which should NOT be bold
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOff()
+
         // Move cursor to beginning (index 0)
         textInputNode.performTextInputSelection(TextRange(0))
 

--- a/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
+++ b/sample-app/src/test/java/dev/mkeeda/arranger/sampleApp/ChatInputSampleTest.kt
@@ -24,6 +24,29 @@ class ChatInputSampleTest {
     val composeTestRule = createComposeRule()
 
     @Test
+    fun `toolbar buttons toggle formatting on selection when clicked`() {
+        composeTestRule.setContent {
+            ArrangerTheme {
+                ChatInputSample()
+            }
+        }
+
+        val textInputNode = composeTestRule.onNodeWithTag("ChatInputEditor")
+        textInputNode.performTextInput("Hello World")
+
+        // Select "Hello"
+        textInputNode.performTextInputSelection(TextRange(0, 5))
+
+        // Toggle Bold on
+        composeTestRule.onNodeWithContentDescription("Bold").performClick()
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOn()
+
+        // Toggle Bold off
+        composeTestRule.onNodeWithContentDescription("Bold").performClick()
+        composeTestRule.onNodeWithContentDescription("Bold").assertIsOff()
+    }
+
+    @Test
     fun `toolbar buttons sync with cursor position attributes`() {
         composeTestRule.setContent {
             ArrangerTheme {


### PR DESCRIPTION
## Overview
This PR introduces comprehensive improvements to the RichTextEditor's toolbar UX and attribute tracking at the cursor level. It implements a robust "Typing Attributes" system that allows users to toggle formatting states without an active text selection, accurately reflects the cursor's formatting state in the UI toolbar, and elegantly handles the explicit removal of inherited styles during typing.

## Key Features & Implementation Details

### 1. Typing Attributes (Format Toggling at Cursor)
- **Feature**: Users can now click formatting buttons (like Bold or Italic) when there is no text selected. The newly typed text will automatically inherit the toggled attribute.
- **Implementation**: Introduced `typingAttributes` in `RichTextState` to store attributes pending text insertion. 

### 2. Cursor State Reflection
- **Feature**: The formatting toolbar buttons now dynamically highlight (toggle ON/OFF) based on the exact formatting attributes present at the current cursor position.
- **Implementation**: `currentAttributes` now computes the exact active attributes at the selection/cursor, combining inherited text spans with any pending `typingAttributes`.

### 3. Explicit Style Removal (`removedTypingAttributes`)
- **Feature**: Solved the edge-case where typing at the end of or inside a styled text span automatically inherits the style. Users can now explicitly click the active formatting button to turn it OFF, and subsequent typing will be unstyled.
- **Implementation**: Introduced the `removedTypingAttributes` property to track explicitly disabled attributes. `currentAttributes` computation and text insertion logic filter out these removed attributes, overriding the default span inheritance.

### 4. Sample App Toolbar Refactoring
- **Refactoring**: Encapsulated the formatting action logic inside `ChatInputSample.kt` by converting `FormatAction` into a `sealed interface` (`Span` and `Paragraph`). 
- **Benefit**: This dramatically simplifies the UI code, removes redundant lambda boilerplate, and elegantly resolves generic type projection issues when toggling attributes.

### 5. Testing
- Reorganized and added robust UI-level tests in `RichTextEditorTest` and `ChatInputSampleTest` using `performTextInput` to verify these typing behaviors.
- Ensured tests validate behavior from a user's perspective (e.g., toggling attributes correctly prevents inheritance at both the edge and middle of styled text spans).