### PR TITLE
docs(readme): improve project appeal for OSS contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,23 @@
 
 Thank you for your interest in contributing to Arranger! This document outlines our development process, versioning strategy, and release workflow.
 
+## Reporting Issues
+
+If you find a bug or have a feature request, please open an issue on GitHub.
+To help us resolve issues quickly, please include the following information:
+
+**For Bug Reports:**
+* **Expected behavior**: What did you expect to happen?
+* **Actual behavior**: What actually happened? (Include screenshots or GIFs if it's a UI issue).
+* **Steps to reproduce**: A clear and concise list of steps to reproduce the issue.
+* **Environment**: Your Android OS version, Compose version, and device/emulator details.
+
+**For Feature Requests:**
+* **Use case**: Why do you need this feature? What problem does it solve?
+* **Proposed API/Solution**: If you have an idea of how the API should look, please share it!
+
+If you'd like to work on an issue yourself, please comment on it first to let us know, so we can avoid duplicate effort.
+
 ## Versioning Strategy (0.x.x Phase)
 
 Arranger follows [Semantic Versioning](https://semver.org/), but while we are in the `0.x.x` pre-v1.0 phase, we apply the following specific rules to set clear expectations:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,72 @@
 # Arranger - Type-safe Rich Text for Jetpack Compose
 
+[![CI](https://github.com/mkeeda/arranger/actions/workflows/ci.yml/badge.svg)](https://github.com/mkeeda/arranger/actions/workflows/ci.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/dev.mkeeda.arranger/arranger-richtext-editor.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22dev.mkeeda.arranger%22%20AND%20a:%22arranger-richtext-editor%22)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+Arranger is a declarative, type-safe rich text library for Jetpack Compose (Kotlin Multiplatform support is planned on the roadmap).
+Inspired by SwiftUI's AttributedString, it eliminates the tedious and error-prone index manipulations of traditional AnnotatedString, giving you a modern, immutable, and fully type-safe API for rich text formatting.
+
 > [!WARNING]
-> **Work In Progress**: This library is currently under active development. APIs are unstable and subject to change without notice.
+> **Work In Progress**: This library is currently under active development. APIs are unstable and subject to change without notice. We highly welcome your feedback, feature requests, and bug reports via GitHub Issues!
 
 ## Requirements
 * **Android API Level 26+**
 * **Jetpack Compose 1.7+**
 * **Kotlin 2.3.20+**
 
-## Project Vision & Features
-The goal of "Arranger" is to provide a "declarative, type-safe, and immutable string manipulation experience similar to SwiftUI's `AttributedString`" to Jetpack Compose and Kotlin Multiplatform (KMP). We aim to break away from the tedious, error-prone index manipulations required by the existing `AnnotatedString` and the traditional WYSIWYG approaches.
+## Core Features
 
-* **Type-Safe Custom Attributes:** Define and apply UI-specific styles (like `SpanStyle`) and domain-specific attributes (e.g., `@Mention`, `#Hashtag`) with full compile-time safety.
-* **Run-Based Manipulation:** Treat text not just as an array of characters, but as "Runs" (chunks of text with identical attributes). This allows for semantic iteration, searching, and editing.
-* **Declarative Formatting Constraints:** Provide a way to declaratively define constraints (e.g., "This text field only allows bold text and links") to automatically strip unwanted styles during paste or input.
-* **Native Compose Integration (1.7+):** Elegantly separate state management and UI rendering by leveraging the latest `TextFieldState` and `OutputTransformation`.
+* 🛡️ **Type-Safe Custom Attributes:** Define and apply UI-specific styles (like `SpanStyle`) and domain-specific attributes (e.g., `@Mention`, `#Hashtag`) with full compile-time safety.
+* 🔄 **Atomic Mutations:** Safely insert, delete, and replace text. Arranger automatically tracks and shifts span indices, eliminating manual calculation errors.
+* 🔍 **Semantic "Runs":** Treat text not just as characters, but as "Runs" (chunks of text with identical attributes). This allows for semantic iteration, searching, and batch editing.
+* 🎨 **Declarative Constraints (Planned):** Provide a way to declaratively define constraints (e.g., "This text field only allows bold text and links") to automatically strip unwanted styles.
+* 🧩 **Native Compose Integration (1.7+):** Elegantly separate state management and UI rendering by leveraging the latest `TextFieldState` and `OutputTransformation`.
 
-## Why Arranger? (Inspiration from SwiftUI)
-Compared to Android's traditional `SpannableStringBuilder` or Compose's `AnnotatedString`, Arranger offers a superior, modern API design:
-* **Semantic "Runs":** Instead of managing `startIndex` and `endIndex`, developers can iterate over `Runs` (e.g., "find all chunks of mentions").
-* **Value Semantics:** The core text data structures are immutable, ensuring thread safety and predictable UI re-rendering, which is highly compatible with Compose.
-* **Type Safety:** We use Kotlin's Extension Functions with receivers to create an intuitive, declarative DSL for composing attributes.
+## Why Arranger?
+
+Arranger solves the biggest pain points of traditional rich text handling in Android and Compose.
+
+### 1. No More Manual Index Math
+When a user types or you programmatically insert text, shifting existing span indices in `AnnotatedString` is tedious and highly error-prone.
+
+**The Pain (`AnnotatedString`)**
+```kotlin
+// The Pain: If a user inserts text, you must manually recalculate all span indices!
+val oldText = "Hello Bold Text"
+val oldSpans = listOf(AnnotatedString.Range(SpanStyle(fontWeight = FontWeight.Bold), 6, 10))
+
+// Inserting "!" at the beginning
+val newText = "!" + oldText
+val newSpans = oldSpans.map { 
+    // Manual index shifting - tedious and highly error-prone
+    AnnotatedString.Range(it.item, it.start + 1, it.end + 1) 
+}
+```
+
+**The Arranger Way**
+Arranger automatically tracks and shifts spans during text mutations.
+```kotlin
+// Arranger Way 1: Automatically tracks and shifts spans during text mutations.
+state.edit {
+    insert(index = 0, text = "!")
+    // The "Bold" span is automatically shifted. No manual index math required!
+}
+```
+
+### 2. Semantic Attribute Search via "Runs"
+Inspired by SwiftUI's `AttributedString.Runs`, Arranger treats text as semantic chunks. You can easily find and batch-edit specific attributes without complex regex or index tracking.
+
+```kotlin
+// Arranger Way 2: Semantic iteration over attributes via "Runs"
+state.edit {
+    // Find all chunks of text that are Bold, and turn them Red at once
+    val boldRuns = state.richString.runs(BoldKey)
+    editAll(boldRuns) {
+        textColor(Color.Red)
+    }
+}
+```
 
 ## Installation
 
@@ -39,7 +85,7 @@ dependencies {
 
 ## Basic Usage (Getting Started)
 
-Arranger's biggest selling point is that you can programmatically construct and decorate RichText using a clean DSL. Simply create a `RichTextState`, decorate it with `editAttributes`, and pass it to the `RichTextEditor`.
+One of the core strengths of Arranger is that you can programmatically construct and decorate RichText using a clean DSL. Simply create a `RichTextState`, decorate it with `editAttributes`, and pass it to the `RichTextEditor`.
 
 ```kotlin
 @Composable
@@ -71,6 +117,9 @@ fun BasicUsageSample(modifier: Modifier = Modifier) {
 ## Paragraph Styles & Advanced Formatting
 
 Arranger natively supports not only inline character formatting (like colors and boldness) but also block-level paragraph formatting such as Headers, Blockquotes, and Alignments.
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 @Composable
@@ -115,6 +164,8 @@ fun AdvancedFormattingSample(modifier: Modifier = Modifier) {
 }
 ```
 
+</details>
+
 <img src="./docs/images/advanced-formatting.png" width="500" alt="advanced formatting sample"/>
 
 ## Lists & Ordered Lists
@@ -123,6 +174,9 @@ Arranger provides native support for `bulletList` and `orderedList` paragraph fo
 
 ### Bullet Lists
 Bullet lists automatically change their marker symbol based on the indentation level (e.g., Level 1 uses `・`, Level 2 uses `○`).
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 @Composable
@@ -159,10 +213,15 @@ fun BulletListSample(modifier: Modifier = Modifier) {
 }
 ```
 
+</details>
+
 <img src="./docs/images/bullet-list.png" width="500" alt="bullet list sample"/>
 
 ### Ordered Lists
 Ordered lists automatically calculate and display the sequence numbers based on their position and nesting level.
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 @Composable
@@ -191,10 +250,15 @@ fun OrderedListSample(modifier: Modifier = Modifier) {
 }
 ```
 
+</details>
+
 <img src="./docs/images/ordered-list.png" width="500" alt="ordered list sample"/>
 
 ### Custom List Markers
 You can customize the list markers by providing a `ListMarkerResolver` to the `RichTextEditor`. This allows you to use different symbols, letters, or parentheses for your lists.
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 private val customMarkerResolver = ListMarkerResolver { item ->
@@ -241,11 +305,16 @@ fun CustomListMarkerSample(modifier: Modifier = Modifier) {
 }
 ```
 
+</details>
+
 <img src="./docs/images/custom-list-marker.png" width="500" alt="custom list marker sample"/>
 
 ## Custom Attribute Mapping
 
 You can define custom attribute keys and map them to Compose styles. Below shows an example of implementing a simple highlight feature by creating a custom `SpanAttributeKey` and styling it with an `AttributeStyleResolver`.
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 // 1. Define Custom Attribute Key
@@ -288,14 +357,19 @@ fun CustomAttributeSample(modifier: Modifier = Modifier) {
 }
 ```
 
+</details>
+
 <img src="./docs/images/custom-attribute.png" width="500" alt="custom attribute mapping sample"/>
 
-## Batch Editing (Searching & Querying)
+## Semantic Batch Editing (Searching & Querying)
 
 Arranger treats text as semantic "Runs" (chunks of text with identical attributes). This allows you to effortlessly search for patterns or query existing attributes, and modify them all at once.
 
 ### Searching and Highlighting
 You can easily search for strings or regular expressions and apply styles to all occurrences at once using `rangesOf` and `editAll`. Here's a sample that highlights hashtags in real-time.
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 @Composable
@@ -332,6 +406,8 @@ fun HashtagHighlightSample(modifier: Modifier = Modifier) {
 }
 ```
 
+</details>
+
 <img src="./docs/images/hashtag-highlight.gif" width="500" alt="hashtag highlighting sample"/>
 
 ### Querying and Modifying Attributes
@@ -339,6 +415,9 @@ Instead of text searching, you can also query existing attributes using `runs(ke
 
 > [!NOTE]
 > For more complex queries, you can also use `runs { predicate }` to extract runs that match any custom condition based on their attributes.
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 @Composable
@@ -387,12 +466,17 @@ fun AttributeBatchEditSample(modifier: Modifier = Modifier) {
 }
 ```
 
+</details>
+
 <img src="./docs/images/attribute-batch-edit.gif" width="500" alt="attribute batch edit sample"/>
 
 ## Atomic Text Mutations
 
 Arranger allows you to programmatically mutate text (`insert`, `delete`, `replace`) and apply formatting atomically within the `RichTextState.edit { }` block.
 The `RichTextBuffer` automatically shifts existing spans to maintain alignment and allows you to apply new attributes safely to the newly inserted text.
+
+<details>
+<summary><b>Show Code</b></summary>
 
 ```kotlin
 @Composable
@@ -433,6 +517,8 @@ fun AtomicMutationSample(modifier: Modifier = Modifier) {
     }
 }
 ```
+
+</details>
 
 ## Practical Examples
 
@@ -483,3 +569,9 @@ To ensure scalability up to PC-class text sizes and pure Kotlin compatibility (K
 - [ ] **Performance Optimization**: Internal migration to Piece Table/Rope structures for document-scale text.
 - [ ] **Kotlin Multiplatform (KMP)**: Full support for iOS, Desktop, and Web.
 
+
+## Contributing
+Contributions are welcome! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started.
+
+## License
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Overview
This PR overhauls the `README.md` and `CONTRIBUTING.md` to make the Arranger library more appealing and accessible to international engineers and potential open-source contributors. It also introduces the `LICENSE` file.

## Implementation Details
- **Added Badges & Elevator Pitch**: Placed CI, Maven Central, and License badges at the top, along with a concise elevator pitch clarifying the project's goals (and noting that KMP support is planned).
- **Emphasized "Why Arranger?"**: Rewrote the motivation section to clearly compare the pain of manual index shifting in `AnnotatedString` versus the automated "Atomic Mutations" in Arranger.
- **Highlighted Semantic Runs**: Added examples demonstrating the SwiftUI-inspired semantic batch editing capabilities using "Runs".
- **Improved Scannability**: Collapsed long, advanced code samples into `<details>` tags so the README is easier to browse.
- **OSS Foundations**:
  - Added an Apache 2.0 `LICENSE` file to the repository root.
  - Added a "Reporting Issues" section in `CONTRIBUTING.md` with guidelines for bug reports and feature requests.