### PR TITLE
chore(spotless): explicitly define editorconfig path for ktlint to apply no-unused-imports rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 # https://editorconfig.org/
 # This configuration is used by ktlint when spotless invokes it
+root = true
 
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma=true
@@ -16,3 +17,4 @@ ktlint_standard_function-type-modifier-spacing = disabled
 ktlint_standard_multiline-loop = disabled
 ktlint_standard_function-signature = disabled
 ktlint_property_naming_constant_naming = pascal_case
+ktlint_standard_no-unused-imports = enabled

--- a/build-logic/convention/src/main/kotlin/AndroidSpotlessConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidSpotlessConventionPlugin.kt
@@ -17,12 +17,12 @@ class AndroidSpotlessConventionPlugin : Plugin<Project> {
                 kotlin {
                     target("**/*.kt")
                     targetExclude("**/build/**/*.kt")
-                    ktlint(ktlintVersion)
+                    ktlint(ktlintVersion).setEditorConfigPath(target.rootProject.file(".editorconfig"))
                 }
                 kotlinGradle {
                     target("**/*.kts")
                     targetExclude("**/build/**/*.kts")
-                    ktlint(ktlintVersion)
+                    ktlint(ktlintVersion).setEditorConfigPath(target.rootProject.file(".editorconfig"))
                 }
                 format("xml") {
                     target("**/*.xml")


### PR DESCRIPTION
## Overview
This PR fixes the issue where Spotless's ktlint integration fails to remove unused imports. In ktlint 1.0.0 and above, the `no-unused-imports` rule is disabled by default and must be explicitly enabled via `.editorconfig`. Additionally, in a multi-module project setup, Spotless requires an explicit path to the root `.editorconfig` file to apply the rules correctly.

## Implementation Details
- Added `ktlint_standard_no-unused-imports = enabled` to explicitly enable the unused import removal rule.
- Added `root = true` to the `.editorconfig` file to prevent ktlint from searching higher up the directory tree.
- Explicitly configured `setEditorConfigPath(target.rootProject.file(".editorconfig"))` in `AndroidSpotlessConventionPlugin.kt` to ensure ktlint properly discovers the configuration file.