### PR TITLE
refactor(richtext): replace getOrNull with get operator for bracket access

### DIFF
--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolver.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/AttributeStyleResolver.kt
@@ -75,7 +75,7 @@ public class AttributeStyleBuilder internal constructor() {
         mapper: (T) -> SpanStyle,
     ) {
         spanResolvers.add { container ->
-            val value = container.getOrNull(key)
+            val value = container[key]
             if (value != null) mapper(value) else null
         }
     }
@@ -89,7 +89,7 @@ public class AttributeStyleBuilder internal constructor() {
         mapper: (T) -> ParagraphStyle,
     ) {
         paragraphResolvers.add { container ->
-            val value = container.getOrNull(key)
+            val value = container[key]
             if (value != null) mapper(value) else null
         }
     }

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/AttributeContainer.kt
@@ -24,7 +24,7 @@ public class AttributeContainer private constructor(
      * If not set, it returns null.
      */
     @Suppress("UNCHECKED_CAST")
-    public fun <T> getOrNull(key: AttributeKey<T>): T? {
+    public operator fun <T> get(key: AttributeKey<T>): T? {
         return attributes[key] as T?
     }
 

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ListItem.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/ListItem.kt
@@ -55,7 +55,7 @@ public fun RichString.extractListItems(): List<ListItem> {
 
                 startIndices.map { startIndex ->
                     val spanAtStart = spans.firstOrNull { startIndex in it.range }
-                    val color = spanAtStart?.attributes?.getOrNull(TextColorKey)
+                    val color = spanAtStart?.attributes?.get(TextColorKey)
                     BulletListItem(
                         textIndex = startIndex,
                         indentLevel = run.value,
@@ -96,7 +96,7 @@ public fun RichString.extractListItems(): List<ListItem> {
                         currentNumbers[currentLevelOrdinal]++
 
                         val spanAtStart = spans.firstOrNull { startIndex in it.range }
-                        val color = spanAtStart?.attributes?.getOrNull(TextColorKey)
+                        val color = spanAtStart?.attributes?.get(TextColorKey)
 
                         add(
                             OrderedListItem(

--- a/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
+++ b/richtext/src/main/kotlin/dev/mkeeda/arranger/richtext/RichString.kt
@@ -32,7 +32,7 @@ public data class RichString(
      * into a single [RichRun], ignoring differences in other attributes.
      */
     public fun <T : Any> runs(key: AttributeKey<T>): Sequence<RichRun<T>> {
-        return extractRuns { attributes -> attributes.getOrNull(key) }
+        return extractRuns { attributes -> attributes[key] }
     }
 
     /**

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeContainerTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeContainerTest.kt
@@ -14,8 +14,8 @@ class AttributeContainerTest {
                 TextColorKey to RgbaColor(0xFFFF0000),
             )
 
-        val mention: RgbaColor? = container.getOrNull(BackgroundColorKey)
-        val color: RgbaColor? = container.getOrNull(TextColorKey)
+        val mention: RgbaColor? = container[BackgroundColorKey]
+        val color: RgbaColor? = container[TextColorKey]
 
         mention shouldBe RgbaColor(0xFF00FF00)
         color shouldBe RgbaColor(0xFFFF0000)
@@ -41,9 +41,9 @@ class AttributeContainerTest {
         emptyContainer.getOrDefault(BackgroundColorKey) shouldBe RgbaColor.Unspecified
         emptyContainer.getOrDefault(TextColorKey) shouldBe RgbaColor.Unspecified
 
-        // getOrNull
-        emptyContainer.getOrNull(BackgroundColorKey).shouldBeNull()
-        emptyContainer.getOrNull(TextColorKey).shouldBeNull()
+        // bracket access
+        emptyContainer[BackgroundColorKey].shouldBeNull()
+        emptyContainer[TextColorKey].shouldBeNull()
     }
 
     @Test
@@ -63,13 +63,13 @@ class AttributeContainerTest {
         val c2 = c1.plus(BackgroundColorKey, RgbaColor(0xFF00FFFF))
         val c3 = c2.plus(TextColorKey, RgbaColor(0xFFFF0000))
 
-        c1.getOrNull(BackgroundColorKey).shouldBeNull()
+        c1[BackgroundColorKey].shouldBeNull()
 
-        c2.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FFFF)
-        c2.getOrNull(TextColorKey).shouldBeNull()
+        c2[BackgroundColorKey] shouldBe RgbaColor(0xFF00FFFF)
+        c2[TextColorKey].shouldBeNull()
 
-        c3.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FFFF)
-        c3.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        c3[BackgroundColorKey] shouldBe RgbaColor(0xFF00FFFF)
+        c3[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
     }
 
     @Test
@@ -98,9 +98,9 @@ class AttributeContainerTest {
 
         val c2 = c1 - TextColorKey
 
-        c1.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        c2.getOrNull(TextColorKey).shouldBeNull()
-        c2.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        c1[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        c2[TextColorKey].shouldBeNull()
+        c2[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
     }
 
     @Test
@@ -117,15 +117,15 @@ class AttributeContainerTest {
         empty.isEmpty() shouldBe true
 
         val onePair = attributeContainerOf(BackgroundColorKey to RgbaColor(0xFF00FF00))
-        onePair.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        onePair[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
 
         val twoPairs =
             attributeContainerOf(
                 BackgroundColorKey to RgbaColor(0xFF00FF00),
                 TextColorKey to RgbaColor(0xFFFF0000),
             )
-        twoPairs.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
-        twoPairs.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        twoPairs[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
+        twoPairs[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
     }
 
     @Test

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScopeTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/AttributeEditScopeTest.kt
@@ -19,10 +19,10 @@ class AttributeEditScopeTest {
         val spans = str.spans
         spans.size shouldBe 1
         val attrs = spans.first().attributes
-        attrs.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        attrs.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
-        attrs.getOrNull(FontSizeKey) shouldBe TextSize(16f)
-        attrs.getOrNull(BoldKey) shouldBe Unit
+        attrs[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        attrs[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
+        attrs[FontSizeKey] shouldBe TextSize(16f)
+        attrs[BoldKey] shouldBe Unit
     }
 
     @Test
@@ -48,8 +48,8 @@ class AttributeEditScopeTest {
 
         // 5..10 attrs should remain
         secondSpan.range shouldBe 5..10
-        secondSpan.attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        secondSpan.attributes.getOrNull(BoldKey) shouldBe Unit
+        secondSpan.attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        secondSpan.attributes[BoldKey] shouldBe Unit
     }
 
     @Test
@@ -63,7 +63,7 @@ class AttributeEditScopeTest {
         val spans = str.spans
         spans.size shouldBe 1
         spans[0].range shouldBe 0..4
-        spans[0].attributes.getOrNull(BoldKey) shouldBe Unit
+        spans[0].attributes[BoldKey] shouldBe Unit
     }
 
     @Test
@@ -72,7 +72,7 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { textColor(RgbaColor(0xFFFF0000)) }
             }
-        str.spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        str.spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
 
         // Passing Unspecified should clear it
         str =
@@ -99,7 +99,7 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { backgroundColor(RgbaColor(0xFF00FF00)) }
             }
-        str.spans[0].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        str.spans[0].attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
 
         str =
             str.edit {
@@ -124,7 +124,7 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { fontSize(TextSize(16f)) }
             }
-        str.spans[0].attributes.getOrNull(FontSizeKey) shouldBe TextSize(16f)
+        str.spans[0].attributes[FontSizeKey] shouldBe TextSize(16f)
 
         str =
             str.edit {
@@ -149,7 +149,7 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { bold() }
             }
-        str.spans[0].attributes.getOrNull(BoldKey) shouldBe Unit
+        str.spans[0].attributes[BoldKey] shouldBe Unit
 
         str =
             str.edit {
@@ -164,7 +164,7 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { underline() }
             }
-        str.spans[0].attributes.getOrNull(UnderlineKey) shouldBe Unit
+        str.spans[0].attributes[UnderlineKey] shouldBe Unit
 
         str =
             str.edit {
@@ -179,7 +179,7 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { italic() }
             }
-        str.spans[0].attributes.getOrNull(ItalicKey) shouldBe Unit
+        str.spans[0].attributes[ItalicKey] shouldBe Unit
 
         str =
             str.edit {
@@ -194,7 +194,7 @@ class AttributeEditScopeTest {
             RichString("Test").edit {
                 editAttributes { strikethrough() }
             }
-        str.spans[0].attributes.getOrNull(StrikethroughKey) shouldBe Unit
+        str.spans[0].attributes[StrikethroughKey] shouldBe Unit
 
         str =
             str.edit {

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringBatchEditTest.kt
@@ -56,14 +56,14 @@ class RichStringBatchEditTest {
             }
 
         // Query runs that are red
-        val redRuns = original.runs { it.getOrNull(TextColorKey) == RgbaColor(0xFFFF0000) }
+        val redRuns = original.runs { it[TextColorKey] == RgbaColor(0xFFFF0000) }
 
         // Change red runs to blue
         val edited =
             original.edit {
                 editAll(redRuns) { run ->
                     // Ensure run has the expected original value
-                    run.value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+                    run.value[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
                     // Overwrite with Blue
                     textColor(RgbaColor(0xFF0000FF))
                 }

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditSpanTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringEditSpanTest.kt
@@ -25,7 +25,7 @@ class RichStringEditSpanTest {
         val spans = styled.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..4
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
     }
 
     @Test
@@ -38,7 +38,7 @@ class RichStringEditSpanTest {
         val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..4
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFF0000FF)
     }
 
     @Test
@@ -56,17 +56,17 @@ class RichStringEditSpanTest {
 
         val colorSpan =
             spans.first {
-                it.attributes.getOrNull(TextColorKey) != null
+                it.attributes[TextColorKey] != null
             }
         colorSpan.range shouldBe 0..4
-        colorSpan.attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        colorSpan.attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
 
         val mentionSpan =
             spans.first {
-                it.attributes.getOrNull(BackgroundColorKey) != null
+                it.attributes[BackgroundColorKey] != null
             }
         mentionSpan.range shouldBe 7..11
-        mentionSpan.attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        mentionSpan.attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
     }
 
     @Test
@@ -107,7 +107,7 @@ class RichStringEditSpanTest {
         val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 3..3
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFF0000FF)
     }
 
     @Test
@@ -128,16 +128,16 @@ class RichStringEditSpanTest {
         spans shouldHaveSize 3
 
         spans[0].range shouldBe 0..4
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[0].attributes.getOrNull(BackgroundColorKey) shouldBe null
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[0].attributes[BackgroundColorKey] shouldBe null
 
         spans[1].range shouldBe 5..10
-        spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[1].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        spans[1].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[1].attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
 
         spans[2].range shouldBe 11..15
-        spans[2].attributes.getOrNull(TextColorKey) shouldBe null
-        spans[2].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        spans[2].attributes[TextColorKey] shouldBe null
+        spans[2].attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
     }
 
     @Test
@@ -158,16 +158,16 @@ class RichStringEditSpanTest {
         spans shouldHaveSize 3
 
         spans[0].range shouldBe 0..2
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[0].attributes.getOrNull(BackgroundColorKey) shouldBe null
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[0].attributes[BackgroundColorKey] shouldBe null
 
         spans[1].range shouldBe 3..7
-        spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[1].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
+        spans[1].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[1].attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
 
         spans[2].range shouldBe 8..10
-        spans[2].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[2].attributes.getOrNull(BackgroundColorKey) shouldBe null
+        spans[2].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[2].attributes[BackgroundColorKey] shouldBe null
     }
 
     @Test
@@ -183,7 +183,7 @@ class RichStringEditSpanTest {
         val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..10
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFF0000FF)
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFF0000FF)
     }
 
     @Test
@@ -214,14 +214,14 @@ class RichStringEditSpanTest {
         spans[3].range shouldBe 8..10
         spans[4].range shouldBe 11..12
 
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[1].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[1].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
-        spans[2].attributes.getOrNull(TextColorKey) shouldBe null
-        spans[2].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
-        spans[3].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        spans[3].attributes.getOrNull(BackgroundColorKey) shouldBe RgbaColor(0xFF00FF00)
-        spans[4].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[1].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[1].attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
+        spans[2].attributes[TextColorKey] shouldBe null
+        spans[2].attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
+        spans[3].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        spans[3].attributes[BackgroundColorKey] shouldBe RgbaColor(0xFF00FF00)
+        spans[4].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
     }
 
     @Test
@@ -236,7 +236,7 @@ class RichStringEditSpanTest {
         val spans = richString.spans
         spans shouldHaveSize 1
         spans[0].range shouldBe 0..10
-        spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
     }
 
     @Test
@@ -260,7 +260,7 @@ class RichStringEditSpanTest {
 
         // Original remains completely unchanged
         original.spans shouldHaveSize 2
-        original.spans[0].attributes.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        original.spans[0].attributes[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
 
         // Edited contains the new attributes
         edited.runs(BackgroundColorKey).toList()[0].range shouldBe 5..14

--- a/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringRunsTest.kt
+++ b/richtext/src/test/kotlin/dev/mkeeda/arranger/richtext/RichStringRunsTest.kt
@@ -75,11 +75,11 @@ class RichStringRunsTest {
                     ),
             )
 
-        val redRuns = fragmentedString.runs { it.getOrNull(TextColorKey) == RgbaColor(0xFFFF0000) }.toList()
+        val redRuns = fragmentedString.runs { it[TextColorKey] == RgbaColor(0xFFFF0000) }.toList()
 
         redRuns shouldHaveSize 1
         redRuns[0].range shouldBe 0..9
-        redRuns[0].value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
+        redRuns[0].value[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
     }
 
     @Test
@@ -105,24 +105,24 @@ class RichStringRunsTest {
                 }
 
         // Predicate: TextColor is Red
-        val redRuns = richString.runs { it.getOrNull(TextColorKey) == RgbaColor(0xFFFF0000) }.toList()
+        val redRuns = richString.runs { it[TextColorKey] == RgbaColor(0xFFFF0000) }.toList()
 
         redRuns shouldHaveSize 3
 
         // 0..4 and 5..9 are both Red, but they have different attributes (Bold vs Italic), so they are NOT merged.
         redRuns[0].range shouldBe 0..4
-        redRuns[0].value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        redRuns[0].value.getOrNull(BoldKey) shouldBe Unit
+        redRuns[0].value[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        redRuns[0].value[BoldKey] shouldBe Unit
 
         redRuns[1].range shouldBe 5..9
-        redRuns[1].value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        redRuns[1].value.getOrNull(ItalicKey) shouldBe Unit
+        redRuns[1].value[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        redRuns[1].value[ItalicKey] shouldBe Unit
 
         // 10..14 is Blue, so it's skipped.
         // 15..19 is Red, Bold.
         redRuns[2].range shouldBe 15..19
-        redRuns[2].value.getOrNull(TextColorKey) shouldBe RgbaColor(0xFFFF0000)
-        redRuns[2].value.getOrNull(BoldKey) shouldBe Unit
+        redRuns[2].value[TextColorKey] shouldBe RgbaColor(0xFFFF0000)
+        redRuns[2].value[BoldKey] shouldBe Unit
     }
 
     @Test
@@ -143,7 +143,7 @@ class RichStringRunsTest {
         val sequence =
             fragmentedString.runs {
                 evaluatedCount++
-                it.getOrNull(TextColorKey) == RgbaColor(0xFFFF0000)
+                it[TextColorKey] == RgbaColor(0xFFFF0000)
             }
 
         evaluatedCount shouldBe 0 // Not evaluated yet
@@ -172,7 +172,7 @@ class RichStringRunsTest {
                     setSpanAttribute(TextColorKey, RgbaColor(0xFF0000FF), range = 5..9)
                 }
 
-        val blueRuns = richString.runs { it.getOrNull(TextColorKey) == RgbaColor(0xFF0000FF) }.toList()
+        val blueRuns = richString.runs { it[TextColorKey] == RgbaColor(0xFF0000FF) }.toList()
 
         blueRuns shouldHaveSize 1
         blueRuns[0].range shouldBe 5..9

--- a/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
+++ b/sample-app/src/main/java/dev/mkeeda/arranger/sampleApp/ChatInputSample.kt
@@ -345,8 +345,8 @@ private fun IndentOutdentButtons(
     IconButton(
         onClick = {
             val currentLevel =
-                state.currentAttributes.getOrNull(BulletListKey)
-                    ?: state.currentAttributes.getOrNull(OrderedListKey)
+                state.currentAttributes[BulletListKey]
+                    ?: state.currentAttributes[OrderedListKey]
             if (currentLevel != null && currentLevel.ordinal > 0) {
                 val prevLevel = ListIndentLevel.entries[currentLevel.ordinal - 1]
                 state.edit {
@@ -379,8 +379,8 @@ private fun IndentOutdentButtons(
     IconButton(
         onClick = {
             val currentLevel =
-                state.currentAttributes.getOrNull(BulletListKey)
-                    ?: state.currentAttributes.getOrNull(OrderedListKey)
+                state.currentAttributes[BulletListKey]
+                    ?: state.currentAttributes[OrderedListKey]
             if (currentLevel != null && currentLevel.ordinal < ListIndentLevel.Level6.ordinal) {
                 val nextLevel = ListIndentLevel.entries[currentLevel.ordinal + 1]
                 state.edit {


### PR DESCRIPTION
## Overview
This PR refactors `AttributeContainer` by replacing the `getOrNull` function with the `get` operator. This allows attributes to be accessed using the more idiomatic Kotlin bracket syntax (e.g., `container[key]`).

## Implementation Details
- **Removed**: `AttributeContainer.getOrNull(key)`
- **Added**: `AttributeContainer.get(key)` operator function, which maintains the same behavior (returns `null` when the key is not set).
- **Updated**: Replaced all usages of `getOrNull` with bracket access across production code (`AttributeStyleResolver.kt`, `RichString.kt`, `ListItem.kt`) and test files.

## ⚠️ BREAKING CHANGE
The `getOrNull` function has been completely removed from `AttributeContainer`. Any external code relying on this method must be updated to use the bracket access syntax `container[key]`.