### PR TITLE
feat(richtext-editor): integrate undo/redo engine and refactor architecture

### DIFF
--- a/.agents/rules/code-style-guide.md
+++ b/.agents/rules/code-style-guide.md
@@ -36,3 +36,7 @@ https://android.googlesource.com/platform/frameworks/support/+/androidx-main/com
 ## importルール
 - single importのみを使うこと。*を使って複数のクラスをまとめてimportしない。
 - ファイル内でオブジェクト名の被りがない限り、必ずimport文を書いてクラス名等を短く書く。androidx.compose.ui...などのようにフルパッケージ指定は極力避ける。
+
+## テストケース名の表現
+- テスト関数名は英語で記載する
+- ``を使い、スペースを含めた完全な英文にする

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/ComposeParagraphWorkarounds.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/ComposeParagraphWorkarounds.kt
@@ -1,0 +1,82 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.ui.text.ParagraphStyle
+
+internal class ComposeParagraphWorkarounds {
+    private var emptyParagraphIndices: List<Int> = emptyList()
+
+    /**
+     * Maps an original character index to its new index in the transformed text buffer.
+     * This is used when targeting a specific character that may have been shifted by insertions.
+     */
+    fun mapCharacterIndex(originalIndex: Int): Int {
+        return originalIndex + emptyParagraphIndices.count { it <= originalIndex }
+    }
+
+    /**
+     * Maps a style boundary offset to its new position in the transformed text buffer.
+     * This is used for ranges where we want the style to cover newly inserted workaround characters.
+     */
+    fun mapStyleOffset(originalOffset: Int): Int {
+        return originalOffset + emptyParagraphIndices.count { it < originalOffset }
+    }
+
+    fun apply(
+        buffer: TextFieldBuffer,
+        getParagraphStyleAt: (Int) -> ParagraphStyle?,
+    ) {
+        // Reset at the start so callers always see a consistent state in case of mid-frame reads
+        emptyParagraphIndices = emptyList()
+
+        val originalText = buffer.asCharSequence().toString()
+        val originalLength = originalText.length
+
+        // Workaround 1: Compose TextLayoutResult ignores ParagraphStyle for completely empty paragraphs.
+        // This breaks cursor positioning (e.g. list indentation) when typing a newline at the end of a list item.
+        // We find all empty paragraphs and insert a Zero-Width Space (\u200B) to force the style application.
+        // We iterate backwards to avoid index shifting during insertion.
+        val emptyIndices = mutableListOf<Int>()
+        for (i in originalLength downTo 0) {
+            val isLineEmpty = (i == originalLength || originalText[i] == '\n') && (i == 0 || originalText[i - 1] == '\n')
+            if (isLineEmpty && getParagraphStyleAt(i) != null) {
+                emptyIndices.add(i)
+                buffer.replace(i, i, "\u200B")
+            }
+        }
+        emptyParagraphIndices = emptyIndices
+
+        // Workaround 2: Compose interprets `\n` within or at the end of a `ParagraphStyle` span as a hard paragraph separator.
+        // When two adjacent lines have different `ParagraphStyle`s, keeping the `\n` between them causes Compose
+        // to render an unintended extra empty line (double spacing).
+        // By replacing the boundary `\n` with a zero-width non-breaking space (`\uFEFF`) right before rendering,
+        // we eliminate the explicit newline character while letting the style change handle the visual line break.
+        var searchStartIndex = 0
+        while (true) {
+            val i = originalText.indexOf('\n', searchStartIndex)
+            if (i == -1) break
+
+            val styleAtI = getParagraphStyleAt(i)
+            val styleAtNext = getParagraphStyleAt(i + 1)
+
+            val isBoundary = styleAtI != styleAtNext
+            // If the `\n` is the very last character in the text, replacing it would completely remove the trailing
+            // empty line (since there is no text after it to break to).
+            // We only replace it if there is a `ParagraphStyle` spanning the empty region after the `\n`,
+            // because that empty style block itself will force Compose to render the trailing empty line.
+            val isSafeToReplace =
+                if (i == originalLength - 1) {
+                    styleAtNext != null
+                } else {
+                    true
+                }
+
+            if (isBoundary && isSafeToReplace) {
+                val mappedI = mapCharacterIndex(i)
+                buffer.replace(mappedI, mappedI + 1, "\uFEFF")
+            }
+
+            searchStartIndex = i + 1
+        }
+    }
+}

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/EditorSnapshot.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/EditorSnapshot.kt
@@ -1,0 +1,10 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.ui.text.TextRange
+import dev.mkeeda.arranger.richtext.RichSpan
+
+internal data class EditorSnapshot(
+    val text: String,
+    val spans: List<RichSpan>,
+    val selection: TextRange,
+)

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
@@ -118,11 +118,6 @@ public fun RichTextEditor(
                                 true
                             }
 
-                            event.key == Key.Y -> {
-                                if (state.canRedo) state.redo()
-                                true
-                            }
-
                             else -> {
                                 false
                             }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
@@ -109,12 +109,12 @@ public fun RichTextEditor(
                     if (isCommandOrCtrl) {
                         when {
                             event.key == Key.Z && event.isShiftPressed -> {
-                                if (state.canRedo) state.redo()
+                                if (state.undoState.canRedo) state.undoState.redo()
                                 true
                             }
 
                             event.key == Key.Z -> {
-                                if (state.canUndo) state.undo()
+                                if (state.undoState.canUndo) state.undoState.undo()
                                 true
                             }
 

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
@@ -25,6 +25,14 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextMeasurer
@@ -93,6 +101,37 @@ public fun RichTextEditor(
 
                 translate(top = -scrollState.value.toFloat()) {
                     drawListItems(listItems, layoutResult, textMeasurer, currentTextStyle, listMarkerResolver, workarounds)
+                }
+            }
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown) {
+                    val isCommandOrCtrl = event.isCtrlPressed || event.isMetaPressed
+                    if (isCommandOrCtrl) {
+                        when {
+                            event.key == Key.Z && event.isShiftPressed -> {
+                                if (state.canRedo) state.redo()
+                                true
+                            }
+
+                            event.key == Key.Z -> {
+                                if (state.canUndo) state.undo()
+                                true
+                            }
+
+                            event.key == Key.Y -> {
+                                if (state.canRedo) state.redo()
+                                true
+                            }
+
+                            else -> {
+                                false
+                            }
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
                 }
             }
 

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditor.kt
@@ -5,10 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.KeyboardActionHandler
-import androidx.compose.foundation.text.input.OutputTransformation
-import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.TextFieldDecorator
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.runtime.Composable
@@ -25,15 +22,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.takeOrElse
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextPainter
@@ -103,32 +91,7 @@ public fun RichTextEditor(
                     drawListItems(listItems, layoutResult, textMeasurer, currentTextStyle, listMarkerResolver, workarounds)
                 }
             }
-            .onPreviewKeyEvent { event ->
-                if (event.type == KeyEventType.KeyDown) {
-                    val isCommandOrCtrl = event.isCtrlPressed || event.isMetaPressed
-                    if (isCommandOrCtrl) {
-                        when {
-                            event.key == Key.Z && event.isShiftPressed -> {
-                                if (state.undoState.canRedo) state.undoState.redo()
-                                true
-                            }
-
-                            event.key == Key.Z -> {
-                                if (state.undoState.canUndo) state.undoState.undo()
-                                true
-                            }
-
-                            else -> {
-                                false
-                            }
-                        }
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
-            }
+            .richTextKeyboardShortcuts(state)
 
     BasicTextField(
         state = state.textFieldState,
@@ -184,130 +147,5 @@ private fun DrawScope.drawListItems(
         canvas.translate(dx = xCenter - textLayout.size.width / 2f, dy = yCenter - textLayout.size.height / 2f)
         TextPainter.paint(canvas = canvas, textLayoutResult = textLayout)
         canvas.restore()
-    }
-}
-
-internal class ComposeParagraphWorkarounds {
-    private var emptyParagraphIndices: List<Int> = emptyList()
-
-    /**
-     * Maps an original character index to its new index in the transformed text buffer.
-     * This is used when targeting a specific character that may have been shifted by insertions.
-     */
-    fun mapCharacterIndex(originalIndex: Int): Int {
-        return originalIndex + emptyParagraphIndices.count { it <= originalIndex }
-    }
-
-    /**
-     * Maps a style boundary offset to its new position in the transformed text buffer.
-     * This is used for ranges where we want the style to cover newly inserted workaround characters.
-     */
-    fun mapStyleOffset(originalOffset: Int): Int {
-        return originalOffset + emptyParagraphIndices.count { it < originalOffset }
-    }
-
-    fun apply(
-        buffer: TextFieldBuffer,
-        getParagraphStyleAt: (Int) -> ParagraphStyle?,
-    ) {
-        // Reset at the start so callers always see a consistent state in case of mid-frame reads
-        emptyParagraphIndices = emptyList()
-
-        val originalText = buffer.asCharSequence().toString()
-        val originalLength = originalText.length
-
-        // Workaround 1: Compose TextLayoutResult ignores ParagraphStyle for completely empty paragraphs.
-        // This breaks cursor positioning (e.g. list indentation) when typing a newline at the end of a list item.
-        // We find all empty paragraphs and insert a Zero-Width Space (\u200B) to force the style application.
-        // We iterate backwards to avoid index shifting during insertion.
-        val emptyIndices = mutableListOf<Int>()
-        for (i in originalLength downTo 0) {
-            val isLineEmpty = (i == originalLength || originalText[i] == '\n') && (i == 0 || originalText[i - 1] == '\n')
-            if (isLineEmpty && getParagraphStyleAt(i) != null) {
-                emptyIndices.add(i)
-                buffer.replace(i, i, "\u200B")
-            }
-        }
-        emptyParagraphIndices = emptyIndices
-
-        // Workaround 2: Compose interprets `\n` within or at the end of a `ParagraphStyle` span as a hard paragraph separator.
-        // When two adjacent lines have different `ParagraphStyle`s, keeping the `\n` between them causes Compose
-        // to render an unintended extra empty line (double spacing).
-        // By replacing the boundary `\n` with a zero-width non-breaking space (`\uFEFF`) right before rendering,
-        // we eliminate the explicit newline character while letting the style change handle the visual line break.
-        var searchStartIndex = 0
-        while (true) {
-            val i = originalText.indexOf('\n', searchStartIndex)
-            if (i == -1) break
-
-            val styleAtI = getParagraphStyleAt(i)
-            val styleAtNext = getParagraphStyleAt(i + 1)
-
-            val isBoundary = styleAtI != styleAtNext
-            // If the `\n` is the very last character in the text, replacing it would completely remove the trailing
-            // empty line (since there is no text after it to break to).
-            // We only replace it if there is a `ParagraphStyle` spanning the empty region after the `\n`,
-            // because that empty style block itself will force Compose to render the trailing empty line.
-            val isSafeToReplace =
-                if (i == originalLength - 1) {
-                    styleAtNext != null
-                } else {
-                    true
-                }
-
-            if (isBoundary && isSafeToReplace) {
-                val mappedI = mapCharacterIndex(i)
-                buffer.replace(mappedI, mappedI + 1, "\uFEFF")
-            }
-
-            searchStartIndex = i + 1
-        }
-    }
-}
-
-internal class RichTextOutputTransformation(
-    private val state: RichTextState,
-    private val styleResolver: AttributeStyleResolver,
-    private val workarounds: ComposeParagraphWorkarounds,
-) : OutputTransformation {
-    override fun TextFieldBuffer.transformOutput() {
-        // Pre-resolve styles for all spans to avoid redundant object allocations
-        val resolvedSpans =
-            state.richString.spans.map { span ->
-                span to styleResolver.resolve(span.attributes)
-            }
-
-        fun getParagraphStyleAt(index: Int): ParagraphStyle? {
-            val resolvedSpan = resolvedSpans.find { index in it.first.range }
-            return resolvedSpan?.second?.paragraphStyle
-        }
-
-        workarounds.apply(this, ::getParagraphStyleAt)
-
-        state.richString.spans.forEach { span ->
-            val resolved = resolvedSpans.find { it.first == span }?.second ?: return@forEach
-            val originalStart = span.range.first
-            val originalEnd = span.range.last + 1
-
-            val start = workarounds.mapStyleOffset(originalStart).coerceIn(0, length)
-            val end = workarounds.mapStyleOffset(originalEnd).coerceIn(0, length)
-
-            if (start < end) {
-                resolved.spanStyle?.let { style ->
-                    addStyle(spanStyle = style, start = start, end = end)
-                }
-                resolved.paragraphStyle?.let { style ->
-                    addStyle(paragraphStyle = style, start = start, end = end)
-                }
-            }
-        }
-    }
-}
-
-private class RichTextInputTransformation(
-    private val state: RichTextState,
-) : InputTransformation {
-    override fun TextFieldBuffer.transformInput() {
-        state.updateRichString(this)
     }
 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextInputTransformation.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextInputTransformation.kt
@@ -1,0 +1,12 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+
+internal class RichTextInputTransformation(
+    private val state: RichTextState,
+) : InputTransformation {
+    override fun TextFieldBuffer.transformInput() {
+        state.updateRichString(this)
+    }
+}

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextKeyboardShortcuts.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextKeyboardShortcuts.kt
@@ -1,0 +1,39 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+
+internal fun Modifier.richTextKeyboardShortcuts(state: RichTextState): Modifier =
+    this.onPreviewKeyEvent { event ->
+        if (event.type == KeyEventType.KeyDown) {
+            val isCommandOrCtrl = event.isCtrlPressed || event.isMetaPressed
+            if (isCommandOrCtrl) {
+                when {
+                    event.key == Key.Z && event.isShiftPressed -> {
+                        if (state.undoState.canRedo) state.undoState.redo()
+                        true
+                    }
+
+                    event.key == Key.Z -> {
+                        if (state.undoState.canUndo) state.undoState.undo()
+                        true
+                    }
+
+                    else -> {
+                        false
+                    }
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextOutputTransformation.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextOutputTransformation.kt
@@ -1,0 +1,44 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.ui.text.ParagraphStyle
+
+internal class RichTextOutputTransformation(
+    private val state: RichTextState,
+    private val styleResolver: AttributeStyleResolver,
+    private val workarounds: ComposeParagraphWorkarounds,
+) : OutputTransformation {
+    override fun TextFieldBuffer.transformOutput() {
+        // Pre-resolve styles for all spans to avoid redundant object allocations
+        val resolvedSpans =
+            state.richString.spans.map { span ->
+                span to styleResolver.resolve(span.attributes)
+            }
+
+        fun getParagraphStyleAt(index: Int): ParagraphStyle? {
+            val resolvedSpan = resolvedSpans.find { index in it.first.range }
+            return resolvedSpan?.second?.paragraphStyle
+        }
+
+        workarounds.apply(this, ::getParagraphStyleAt)
+
+        state.richString.spans.forEach { span ->
+            val resolved = resolvedSpans.find { it.first == span }?.second ?: return@forEach
+            val originalStart = span.range.first
+            val originalEnd = span.range.last + 1
+
+            val start = workarounds.mapStyleOffset(originalStart).coerceIn(0, length)
+            val end = workarounds.mapStyleOffset(originalEnd).coerceIn(0, length)
+
+            if (start < end) {
+                resolved.spanStyle?.let { style ->
+                    addStyle(spanStyle = style, start = start, end = end)
+                }
+                resolved.paragraphStyle?.let { style ->
+                    addStyle(paragraphStyle = style, start = start, end = end)
+                }
+            }
+        }
+    }
+}

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -551,7 +551,7 @@ private fun shiftSpan(
     }
 }
 
-@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 internal fun resolveMergePolicy(buffer: TextFieldBuffer): UndoMergePolicy {
     if (buffer.changes.changeCount != 1) return UndoMergePolicy.Separate
 

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -305,6 +305,10 @@ public class RichTextState(initialText: RichString) {
         clearTypingAttributes()
     }
 
+    /**
+     * Manages the undo and redo history for this state.
+     * Use this property to programmatically trigger undo/redo operations or observe their availability.
+     */
     public val undoState: RichTextUndoState =
         RichTextUndoState(
             textFieldState = textFieldState,

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -25,8 +25,6 @@ import dev.mkeeda.arranger.richtext.snapToParagraphs
 public class RichTextState(initialText: RichString) {
     internal val textFieldState = TextFieldState(initialText.text)
 
-    internal val undoManager = RichTextUndoManager()
-
     // The Single Source of Truth for spans
     private var spans: List<RichSpan> by mutableStateOf(initialText.spans.resnapParagraphSpans(initialText.text))
 

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -551,9 +551,9 @@ private fun shiftSpan(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 internal fun resolveMergePolicy(buffer: TextFieldBuffer): UndoMergePolicy {
-    if (buffer.changes.changeCount != 1) return UndoMergePolicy.SEPARATE
+    if (buffer.changes.changeCount != 1) return UndoMergePolicy.Separate
 
     val range = buffer.changes.getRange(0)
     val originalRange = buffer.changes.getOriginalRange(0)
@@ -562,13 +562,13 @@ internal fun resolveMergePolicy(buffer: TextFieldBuffer): UndoMergePolicy {
     val deletedLength = originalRange.length
 
     // Deletion always creates a new undo entry
-    if (deletedLength > 0) return UndoMergePolicy.SEPARATE
+    if (deletedLength > 0) return UndoMergePolicy.Separate
 
     // Paste (multiple characters) always creates a new undo entry
-    if (insertedText.length > 1) return UndoMergePolicy.SEPARATE
+    if (insertedText.length > 1) return UndoMergePolicy.Separate
 
     // Space or newline creates a new undo entry
-    if (insertedText.any { it.isWhitespace() }) return UndoMergePolicy.SEPARATE
+    if (insertedText.any { it.isWhitespace() }) return UndoMergePolicy.Separate
 
-    return UndoMergePolicy.MERGE
+    return UndoMergePolicy.Merge
 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -230,8 +230,7 @@ public class RichTextState(initialText: RichString) {
             return
         }
 
-        val snapshotBefore = takeSnapshot()
-        val mergePolicy = resolveMergePolicy(buffer)
+        undoState.captureSnapshotBeforeChange(buffer)
 
         val typingAttr = typingAttributes
         val removedAttr = removedTypingAttributes
@@ -304,53 +303,15 @@ public class RichTextState(initialText: RichString) {
 
         this.spans = newSpans.resnapParagraphSpans(buffer.toString())
         clearTypingAttributes()
-
-        undoManager.pushSnapshot(snapshotBefore, mergePolicy)
     }
 
-    private fun takeSnapshot(): EditorSnapshot {
-        return EditorSnapshot(
-            text = textFieldState.text.toString(),
-            spans = spans,
-            selection = textFieldState.selection,
+    public val undoState: RichTextUndoState =
+        RichTextUndoState(
+            textFieldState = textFieldState,
+            getSpans = { spans },
+            setSpans = { spans = it },
+            clearTypingAttributes = { clearTypingAttributes() },
         )
-    }
-
-    @OptIn(ExperimentalFoundationApi::class)
-    private fun restoreSnapshot(snapshot: EditorSnapshot) {
-        textFieldState.edit {
-            replace(0, length, snapshot.text)
-            selection = snapshot.selection
-        }
-        textFieldState.undoState.clearHistory()
-        this.spans = snapshot.spans
-        clearTypingAttributes()
-    }
-
-    public val undoState: RichTextUndoState = RichTextUndoState()
-
-    public inner class RichTextUndoState {
-        public val canUndo: Boolean get() = undoManager.canUndo
-        public val canRedo: Boolean get() = undoManager.canRedo
-
-        @OptIn(ExperimentalFoundationApi::class)
-        public fun undo() {
-            val undoneSnapshot = undoManager.undo(takeSnapshot()) ?: return
-            restoreSnapshot(undoneSnapshot)
-        }
-
-        @OptIn(ExperimentalFoundationApi::class)
-        public fun redo() {
-            val redoneSnapshot = undoManager.redo(takeSnapshot()) ?: return
-            restoreSnapshot(redoneSnapshot)
-        }
-
-        @OptIn(ExperimentalFoundationApi::class)
-        public fun clearHistory() {
-            undoManager.clear()
-            textFieldState.undoState.clearHistory()
-        }
-    }
 
     private fun handleNewlineInsertion(
         insertedText: String,
@@ -559,26 +520,4 @@ private fun shiftSpan(
             }
         }
     }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-internal fun resolveMergePolicy(buffer: TextFieldBuffer): UndoMergePolicy {
-    if (buffer.changes.changeCount != 1) return UndoMergePolicy.Separate
-
-    val range = buffer.changes.getRange(0)
-    val originalRange = buffer.changes.getOriginalRange(0)
-
-    val insertedText = buffer.asCharSequence().substring(range.min, range.max)
-    val deletedLength = originalRange.length
-
-    // Deletion always creates a new undo entry
-    if (deletedLength > 0) return UndoMergePolicy.Separate
-
-    // Paste (multiple characters) always creates a new undo entry
-    if (insertedText.length > 1) return UndoMergePolicy.Separate
-
-    // Space or newline creates a new undo entry
-    if (insertedText.any { it.isWhitespace() }) return UndoMergePolicy.Separate
-
-    return UndoMergePolicy.Merge
 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -27,9 +27,6 @@ public class RichTextState(initialText: RichString) {
 
     internal val undoManager = RichTextUndoManager()
 
-    public val canUndo: Boolean get() = undoManager.canUndo
-    public val canRedo: Boolean get() = undoManager.canRedo
-
     // The Single Source of Truth for spans
     private var spans: List<RichSpan> by mutableStateOf(initialText.spans.resnapParagraphSpans(initialText.text))
 
@@ -330,16 +327,29 @@ public class RichTextState(initialText: RichString) {
         clearTypingAttributes()
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
-    public fun undo() {
-        val undoneSnapshot = undoManager.undo(takeSnapshot()) ?: return
-        restoreSnapshot(undoneSnapshot)
-    }
+    public val undoState: RichTextUndoState = RichTextUndoState()
 
-    @OptIn(ExperimentalFoundationApi::class)
-    public fun redo() {
-        val redoneSnapshot = undoManager.redo(takeSnapshot()) ?: return
-        restoreSnapshot(redoneSnapshot)
+    public inner class RichTextUndoState {
+        public val canUndo: Boolean get() = undoManager.canUndo
+        public val canRedo: Boolean get() = undoManager.canRedo
+
+        @OptIn(ExperimentalFoundationApi::class)
+        public fun undo() {
+            val undoneSnapshot = undoManager.undo(takeSnapshot()) ?: return
+            restoreSnapshot(undoneSnapshot)
+        }
+
+        @OptIn(ExperimentalFoundationApi::class)
+        public fun redo() {
+            val redoneSnapshot = undoManager.redo(takeSnapshot()) ?: return
+            restoreSnapshot(redoneSnapshot)
+        }
+
+        @OptIn(ExperimentalFoundationApi::class)
+        public fun clearHistory() {
+            undoManager.clear()
+            textFieldState.undoState.clearHistory()
+        }
     }
 
     private fun handleNewlineInsertion(

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -308,6 +308,8 @@ public class RichTextState(initialText: RichString) {
     /**
      * Manages the undo and redo history for this state.
      * Use this property to programmatically trigger undo/redo operations or observe their availability.
+     *
+     * See [RichTextUndoState] for details on how the snapshot history is automatically recorded.
      */
     public val undoState: RichTextUndoState =
         RichTextUndoState(

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -25,6 +25,11 @@ import dev.mkeeda.arranger.richtext.snapToParagraphs
 public class RichTextState(initialText: RichString) {
     internal val textFieldState = TextFieldState(initialText.text)
 
+    internal val undoManager = RichTextUndoManager()
+
+    public val canUndo: Boolean get() = undoManager.canUndo
+    public val canRedo: Boolean get() = undoManager.canRedo
+
     // The Single Source of Truth for spans
     private var spans: List<RichSpan> by mutableStateOf(initialText.spans.resnapParagraphSpans(initialText.text))
 
@@ -228,6 +233,9 @@ public class RichTextState(initialText: RichString) {
             return
         }
 
+        val snapshotBefore = takeSnapshot()
+        val mergePolicy = resolveMergePolicy(buffer)
+
         val typingAttr = typingAttributes
         val removedAttr = removedTypingAttributes
 
@@ -299,6 +307,39 @@ public class RichTextState(initialText: RichString) {
 
         this.spans = newSpans.resnapParagraphSpans(buffer.toString())
         clearTypingAttributes()
+
+        undoManager.pushSnapshot(snapshotBefore, mergePolicy)
+    }
+
+    private fun takeSnapshot(): EditorSnapshot {
+        return EditorSnapshot(
+            text = textFieldState.text.toString(),
+            spans = spans,
+            selection = textFieldState.selection
+        )
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    private fun restoreSnapshot(snapshot: EditorSnapshot) {
+        textFieldState.edit {
+            replace(0, length, snapshot.text)
+            selection = snapshot.selection
+        }
+        textFieldState.undoState.clearHistory()
+        this.spans = snapshot.spans
+        clearTypingAttributes()
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    public fun undo() {
+        val undoneSnapshot = undoManager.undo(takeSnapshot()) ?: return
+        restoreSnapshot(undoneSnapshot)
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    public fun redo() {
+        val redoneSnapshot = undoManager.redo(takeSnapshot()) ?: return
+        restoreSnapshot(redoneSnapshot)
     }
 
     private fun handleNewlineInsertion(
@@ -508,4 +549,26 @@ private fun shiftSpan(
             }
         }
     }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+internal fun resolveMergePolicy(buffer: TextFieldBuffer): UndoMergePolicy {
+    if (buffer.changes.changeCount != 1) return UndoMergePolicy.SEPARATE
+    
+    val range = buffer.changes.getRange(0)
+    val originalRange = buffer.changes.getOriginalRange(0)
+    
+    val insertedText = buffer.asCharSequence().substring(range.min, range.max)
+    val deletedLength = originalRange.length
+    
+    // Deletion always creates a new undo entry
+    if (deletedLength > 0) return UndoMergePolicy.SEPARATE
+    
+    // Paste (multiple characters) always creates a new undo entry
+    if (insertedText.length > 1) return UndoMergePolicy.SEPARATE
+    
+    // Space or newline creates a new undo entry
+    if (insertedText.any { it.isWhitespace() }) return UndoMergePolicy.SEPARATE
+    
+    return UndoMergePolicy.MERGE
 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -315,7 +315,7 @@ public class RichTextState(initialText: RichString) {
         return EditorSnapshot(
             text = textFieldState.text.toString(),
             spans = spans,
-            selection = textFieldState.selection
+            selection = textFieldState.selection,
         )
     }
 
@@ -554,21 +554,21 @@ private fun shiftSpan(
 @OptIn(ExperimentalFoundationApi::class)
 internal fun resolveMergePolicy(buffer: TextFieldBuffer): UndoMergePolicy {
     if (buffer.changes.changeCount != 1) return UndoMergePolicy.SEPARATE
-    
+
     val range = buffer.changes.getRange(0)
     val originalRange = buffer.changes.getOriginalRange(0)
-    
+
     val insertedText = buffer.asCharSequence().substring(range.min, range.max)
     val deletedLength = originalRange.length
-    
+
     // Deletion always creates a new undo entry
     if (deletedLength > 0) return UndoMergePolicy.SEPARATE
-    
+
     // Paste (multiple characters) always creates a new undo entry
     if (insertedText.length > 1) return UndoMergePolicy.SEPARATE
-    
+
     // Space or newline creates a new undo entry
     if (insertedText.any { it.isWhitespace() }) return UndoMergePolicy.SEPARATE
-    
+
     return UndoMergePolicy.MERGE
 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
@@ -1,20 +1,18 @@
 package dev.mkeeda.arranger.richtext.editor
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateListOf
 
 internal class RichTextUndoManager(
     private val maxSize: Int = 100,
 ) {
-    private val undoStack = ArrayDeque<EditorSnapshot>()
-    private val redoStack = ArrayDeque<EditorSnapshot>()
+    private val undoStack = mutableStateListOf<EditorSnapshot>()
+    private val redoStack = mutableStateListOf<EditorSnapshot>()
 
-    var canUndo: Boolean by mutableStateOf(false)
-        private set
+    val canUndo: Boolean
+        get() = undoStack.isNotEmpty()
 
-    var canRedo: Boolean by mutableStateOf(false)
-        private set
+    val canRedo: Boolean
+        get() = redoStack.isNotEmpty()
 
     private var lastMergePolicy: UndoMergePolicy? = null
 
@@ -22,40 +20,37 @@ internal class RichTextUndoManager(
         when (mergePolicy) {
             UndoMergePolicy.Merge -> {
                 if (lastMergePolicy != UndoMergePolicy.Merge || undoStack.isEmpty()) {
-                    undoStack.addLast(snapshot)
+                    undoStack.add(snapshot)
                 }
             }
 
             UndoMergePolicy.Separate -> {
-                undoStack.addLast(snapshot)
+                undoStack.add(snapshot)
             }
         }
 
         lastMergePolicy = mergePolicy
 
         if (undoStack.size > maxSize) {
-            undoStack.removeFirst()
+            undoStack.removeAt(0)
         }
 
         redoStack.clear()
-        updateFlags()
     }
 
     fun undo(currentSnapshot: EditorSnapshot): EditorSnapshot? {
         if (undoStack.isEmpty()) return null
-        val previousSnapshot = undoStack.removeLast()
-        redoStack.addLast(currentSnapshot)
+        val previousSnapshot = undoStack.removeAt(undoStack.lastIndex)
+        redoStack.add(currentSnapshot)
         lastMergePolicy = null // Reset merging after undo
-        updateFlags()
         return previousSnapshot
     }
 
     fun redo(currentSnapshot: EditorSnapshot): EditorSnapshot? {
         if (redoStack.isEmpty()) return null
-        val nextSnapshot = redoStack.removeLast()
-        undoStack.addLast(currentSnapshot)
+        val nextSnapshot = redoStack.removeAt(redoStack.lastIndex)
+        undoStack.add(currentSnapshot)
         lastMergePolicy = null // Reset merging after redo
-        updateFlags()
         return nextSnapshot
     }
 
@@ -63,11 +58,5 @@ internal class RichTextUndoManager(
         undoStack.clear()
         redoStack.clear()
         lastMergePolicy = null
-        updateFlags()
-    }
-
-    private fun updateFlags() {
-        canUndo = undoStack.isNotEmpty()
-        canRedo = redoStack.isNotEmpty()
     }
 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
@@ -20,13 +20,13 @@ internal class RichTextUndoManager(
 
     fun pushSnapshot(snapshot: EditorSnapshot, mergePolicy: UndoMergePolicy) {
         when (mergePolicy) {
-            UndoMergePolicy.MERGE -> {
-                if (lastMergePolicy != UndoMergePolicy.MERGE || undoStack.isEmpty()) {
+            UndoMergePolicy.Merge -> {
+                if (lastMergePolicy != UndoMergePolicy.Merge || undoStack.isEmpty()) {
                     undoStack.addLast(snapshot)
                 }
             }
 
-            UndoMergePolicy.SEPARATE -> {
+            UndoMergePolicy.Separate -> {
                 undoStack.addLast(snapshot)
             }
         }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
@@ -16,12 +16,12 @@ internal class RichTextUndoManager(
     var canRedo: Boolean by mutableStateOf(false)
         private set
 
+    private var lastMergePolicy: UndoMergePolicy? = null
+
     fun pushSnapshot(snapshot: EditorSnapshot, mergePolicy: UndoMergePolicy) {
         when (mergePolicy) {
             UndoMergePolicy.MERGE -> {
-                if (undoStack.isNotEmpty()) {
-                    undoStack[undoStack.lastIndex] = snapshot
-                } else {
+                if (lastMergePolicy != UndoMergePolicy.MERGE || undoStack.isEmpty()) {
                     undoStack.addLast(snapshot)
                 }
             }
@@ -29,6 +29,8 @@ internal class RichTextUndoManager(
                 undoStack.addLast(snapshot)
             }
         }
+        
+        lastMergePolicy = mergePolicy
         
         if (undoStack.size > maxSize) {
             undoStack.removeFirst()
@@ -42,6 +44,7 @@ internal class RichTextUndoManager(
         if (undoStack.isEmpty()) return null
         val previousSnapshot = undoStack.removeLast()
         redoStack.addLast(currentSnapshot)
+        lastMergePolicy = null // Reset merging after undo
         updateFlags()
         return previousSnapshot
     }
@@ -50,6 +53,7 @@ internal class RichTextUndoManager(
         if (redoStack.isEmpty()) return null
         val nextSnapshot = redoStack.removeLast()
         undoStack.addLast(currentSnapshot)
+        lastMergePolicy = null // Reset merging after redo
         updateFlags()
         return nextSnapshot
     }
@@ -57,6 +61,7 @@ internal class RichTextUndoManager(
     fun clear() {
         undoStack.clear()
         redoStack.clear()
+        lastMergePolicy = null
         updateFlags()
     }
 

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
@@ -1,0 +1,67 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+internal class RichTextUndoManager(
+    private val maxSize: Int = 100
+) {
+    private val undoStack = ArrayDeque<EditorSnapshot>()
+    private val redoStack = ArrayDeque<EditorSnapshot>()
+
+    var canUndo: Boolean by mutableStateOf(false)
+        private set
+
+    var canRedo: Boolean by mutableStateOf(false)
+        private set
+
+    fun pushSnapshot(snapshot: EditorSnapshot, mergePolicy: UndoMergePolicy) {
+        when (mergePolicy) {
+            UndoMergePolicy.MERGE -> {
+                if (undoStack.isNotEmpty()) {
+                    undoStack[undoStack.lastIndex] = snapshot
+                } else {
+                    undoStack.addLast(snapshot)
+                }
+            }
+            UndoMergePolicy.SEPARATE -> {
+                undoStack.addLast(snapshot)
+            }
+        }
+        
+        if (undoStack.size > maxSize) {
+            undoStack.removeFirst()
+        }
+        
+        redoStack.clear()
+        updateFlags()
+    }
+
+    fun undo(currentSnapshot: EditorSnapshot): EditorSnapshot? {
+        if (undoStack.isEmpty()) return null
+        val previousSnapshot = undoStack.removeLast()
+        redoStack.addLast(currentSnapshot)
+        updateFlags()
+        return previousSnapshot
+    }
+
+    fun redo(currentSnapshot: EditorSnapshot): EditorSnapshot? {
+        if (redoStack.isEmpty()) return null
+        val nextSnapshot = redoStack.removeLast()
+        undoStack.addLast(currentSnapshot)
+        updateFlags()
+        return nextSnapshot
+    }
+
+    fun clear() {
+        undoStack.clear()
+        redoStack.clear()
+        updateFlags()
+    }
+
+    private fun updateFlags() {
+        canUndo = undoStack.isNotEmpty()
+        canRedo = redoStack.isNotEmpty()
+    }
+}

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManager.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
 internal class RichTextUndoManager(
-    private val maxSize: Int = 100
+    private val maxSize: Int = 100,
 ) {
     private val undoStack = ArrayDeque<EditorSnapshot>()
     private val redoStack = ArrayDeque<EditorSnapshot>()
@@ -25,17 +25,18 @@ internal class RichTextUndoManager(
                     undoStack.addLast(snapshot)
                 }
             }
+
             UndoMergePolicy.SEPARATE -> {
                 undoStack.addLast(snapshot)
             }
         }
-        
+
         lastMergePolicy = mergePolicy
-        
+
         if (undoStack.size > maxSize) {
             undoStack.removeFirst()
         }
-        
+
         redoStack.clear()
         updateFlags()
     }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
@@ -11,6 +11,12 @@ import dev.mkeeda.arranger.richtext.RichSpan
  *
  * This state allows you to programmatically trigger [undo], [redo], and [clearHistory] operations,
  * as well as observe the availability of these operations via [canUndo] and [canRedo].
+ *
+ * ### Snapshot Granularity
+ * The undo history is recorded automatically based on the following rules:
+ * - Consecutive single-character typing (e.g., typing "abc") is merged into a single undo step.
+ * - Whitespace, newlines, text deletions (e.g., Backspace, Delete), and pasting multiple
+ *   characters always create a separate undo step.
  */
 @Stable
 public class RichTextUndoState internal constructor(

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
@@ -6,6 +6,12 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Stable
 import dev.mkeeda.arranger.richtext.RichSpan
 
+/**
+ * Manages the undo and redo history for a [RichTextState].
+ *
+ * This state allows you to programmatically trigger [undo], [redo], and [clearHistory] operations,
+ * as well as observe the availability of these operations via [canUndo] and [canRedo].
+ */
 @Stable
 public class RichTextUndoState internal constructor(
     private val textFieldState: TextFieldState,
@@ -15,24 +21,44 @@ public class RichTextUndoState internal constructor(
 ) {
     internal val undoManager = RichTextUndoManager()
 
+    /**
+     * Whether an undo operation is available.
+     * Returns `true` if there is at least one action that can be undone.
+     */
     public val canUndo: Boolean
         get() = undoManager.canUndo
 
+    /**
+     * Whether a redo operation is available.
+     * Returns `true` if there is at least one action that can be redone.
+     */
     public val canRedo: Boolean
         get() = undoManager.canRedo
 
+    /**
+     * Reverts the most recent change made to the text or rich text spans.
+     * If [canUndo] is `false`, this operation does nothing.
+     */
     @OptIn(ExperimentalFoundationApi::class)
     public fun undo() {
         val undoneSnapshot = undoManager.undo(takeSnapshot()) ?: return
         restoreSnapshot(undoneSnapshot)
     }
 
+    /**
+     * Reapplies the most recent change that was undone.
+     * If [canRedo] is `false`, this operation does nothing.
+     */
     @OptIn(ExperimentalFoundationApi::class)
     public fun redo() {
         val redoneSnapshot = undoManager.redo(takeSnapshot()) ?: return
         restoreSnapshot(redoneSnapshot)
     }
 
+    /**
+     * Clears both the undo and redo history.
+     * This resets [canUndo] and [canRedo] to `false`.
+     */
     @OptIn(ExperimentalFoundationApi::class)
     public fun clearHistory() {
         undoManager.clear()

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
@@ -1,0 +1,89 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Stable
+import dev.mkeeda.arranger.richtext.RichSpan
+
+@Stable
+public class RichTextUndoState internal constructor(
+    private val textFieldState: TextFieldState,
+    private val getSpans: () -> List<RichSpan>,
+    private val setSpans: (List<RichSpan>) -> Unit,
+    private val clearTypingAttributes: () -> Unit,
+) {
+    internal val undoManager = RichTextUndoManager()
+
+    public val canUndo: Boolean
+        get() = undoManager.canUndo
+
+    public val canRedo: Boolean
+        get() = undoManager.canRedo
+
+    @OptIn(ExperimentalFoundationApi::class)
+    public fun undo() {
+        val undoneSnapshot = undoManager.undo(takeSnapshot()) ?: return
+        restoreSnapshot(undoneSnapshot)
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    public fun redo() {
+        val redoneSnapshot = undoManager.redo(takeSnapshot()) ?: return
+        restoreSnapshot(redoneSnapshot)
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    public fun clearHistory() {
+        undoManager.clear()
+        textFieldState.undoState.clearHistory()
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    internal fun captureSnapshotBeforeChange(buffer: TextFieldBuffer) {
+        val snapshotBefore = takeSnapshot()
+        val mergePolicy = resolveMergePolicy(buffer)
+        undoManager.pushSnapshot(snapshotBefore, mergePolicy)
+    }
+
+    private fun takeSnapshot(): EditorSnapshot {
+        return EditorSnapshot(
+            text = textFieldState.text.toString(),
+            spans = getSpans(),
+            selection = textFieldState.selection,
+        )
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    private fun restoreSnapshot(snapshot: EditorSnapshot) {
+        textFieldState.edit {
+            replace(0, length, snapshot.text)
+            selection = snapshot.selection
+        }
+        textFieldState.undoState.clearHistory()
+        setSpans(snapshot.spans)
+        clearTypingAttributes()
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+internal fun resolveMergePolicy(buffer: TextFieldBuffer): UndoMergePolicy {
+    if (buffer.changes.changeCount != 1) return UndoMergePolicy.Separate
+
+    val range = buffer.changes.getRange(0)
+    val originalRange = buffer.changes.getOriginalRange(0)
+
+    val insertedText = buffer.asCharSequence().substring(range.min, range.max)
+    val deletedLength = originalRange.length
+
+    // Deletion always creates a new undo entry
+    if (deletedLength > 0) return UndoMergePolicy.Separate
+
+    // Paste (multiple characters) always creates a new undo entry
+    if (insertedText.length > 1) return UndoMergePolicy.Separate
+
+    // Space or newline creates a new undo entry
+    if (insertedText.any { it.isWhitespace() }) return UndoMergePolicy.Separate
+
+    return UndoMergePolicy.Merge
+}

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoState.kt
@@ -64,6 +64,8 @@ public class RichTextUndoState internal constructor(
     /**
      * Clears both the undo and redo history.
      * This resets [canUndo] and [canRedo] to `false`.
+     *
+     * Note: This also clears the internal [TextFieldState] undo history to keep both in sync.
      */
     @OptIn(ExperimentalFoundationApi::class)
     public fun clearHistory() {

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/UndoMergePolicy.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/UndoMergePolicy.kt
@@ -1,0 +1,6 @@
+package dev.mkeeda.arranger.richtext.editor
+
+internal enum class UndoMergePolicy {
+    MERGE,
+    SEPARATE
+}

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/UndoMergePolicy.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/UndoMergePolicy.kt
@@ -1,6 +1,6 @@
 package dev.mkeeda.arranger.richtext.editor
 
 internal enum class UndoMergePolicy {
-    MERGE,
-    SEPARATE,
+    Merge,
+    Separate,
 }

--- a/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/UndoMergePolicy.kt
+++ b/richtext-editor/src/main/kotlin/dev/mkeeda/arranger/richtext/editor/UndoMergePolicy.kt
@@ -2,5 +2,5 @@ package dev.mkeeda.arranger.richtext.editor
 
 internal enum class UndoMergePolicy {
     MERGE,
-    SEPARATE
+    SEPARATE,
 }

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -1,5 +1,6 @@
 package dev.mkeeda.arranger.richtext.editor
 
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performKeyInput
@@ -441,7 +442,7 @@ class RichTextEditorTest {
         spans[1].attributes shouldBe attributeContainerOf(BulletListKey to ListIndentLevel.Level2)
     }
 
-    @androidx.compose.ui.test.ExperimentalTestApi
+    @OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
     @Test
     fun `undo and redo via keyboard shortcuts`() {
         val initialText = "Hello"
@@ -463,10 +464,10 @@ class RichTextEditorTest {
 
         // Simulate Ctrl+Z (Undo)
         composeTestRule.onNodeWithText(expectedNewText).performKeyInput {
-            keyDown(androidx.compose.ui.input.key.Key.CtrlLeft)
-            keyDown(androidx.compose.ui.input.key.Key.Z)
-            keyUp(androidx.compose.ui.input.key.Key.Z)
-            keyUp(androidx.compose.ui.input.key.Key.CtrlLeft)
+            keyDown(Key.CtrlLeft)
+            keyDown(Key.Z)
+            keyUp(Key.Z)
+            keyUp(Key.CtrlLeft)
         }
         composeTestRule.waitForIdle()
 
@@ -478,12 +479,12 @@ class RichTextEditorTest {
 
         // Simulate Ctrl+Shift+Z (Redo)
         composeTestRule.onNodeWithText("Hello").performKeyInput {
-            keyDown(androidx.compose.ui.input.key.Key.CtrlLeft)
-            keyDown(androidx.compose.ui.input.key.Key.ShiftLeft)
-            keyDown(androidx.compose.ui.input.key.Key.Z)
-            keyUp(androidx.compose.ui.input.key.Key.Z)
-            keyUp(androidx.compose.ui.input.key.Key.ShiftLeft)
-            keyUp(androidx.compose.ui.input.key.Key.CtrlLeft)
+            keyDown(Key.CtrlLeft)
+            keyDown(Key.ShiftLeft)
+            keyDown(Key.Z)
+            keyUp(Key.Z)
+            keyUp(Key.ShiftLeft)
+            keyUp(Key.CtrlLeft)
         }
         composeTestRule.waitForIdle()
 

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -472,10 +472,8 @@ class RichTextEditorTest {
         }
         composeTestRule.waitForIdle()
 
-        // Because " World" involves space and word, we might need two undos,
-        // but wait, `performTextInput(" World")` might be delivered as a single string replacing it.
-        // Wait, `simulateTypingAtEnd` sends char by char. `performTextInput` replaces the whole thing.
-        // Let's check what state we are in. If we just verify state.richString.text == "Hello" it's fine.
+        // `performTextInput(" World")` is delivered as a single bulk operation, creating one undo entry.
+        // A single Ctrl+Z should therefore revert the entire " World" addition.
         state.richString.text shouldBe "Hello"
 
         // Simulate Ctrl+Shift+Z (Redo)

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -1,6 +1,7 @@
 package dev.mkeeda.arranger.richtext.editor
 
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performKeyInput
@@ -442,7 +443,7 @@ class RichTextEditorTest {
         spans[1].attributes shouldBe attributeContainerOf(BulletListKey to ListIndentLevel.Level2)
     }
 
-    @OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+    @OptIn(ExperimentalTestApi::class)
     @Test
     fun `undo and redo via keyboard shortcuts`() {
         val initialText = "Hello"

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextEditorTest.kt
@@ -2,6 +2,7 @@ package dev.mkeeda.arranger.richtext.editor
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextInputSelection
 import androidx.compose.ui.text.SpanStyle
@@ -438,5 +439,54 @@ class RichTextEditorTest {
         spans[0].attributes shouldBe attributeContainerOf(BulletListKey to ListIndentLevel.Level1)
         spans[1].range shouldBe (7..13)
         spans[1].attributes shouldBe attributeContainerOf(BulletListKey to ListIndentLevel.Level2)
+    }
+
+    @androidx.compose.ui.test.ExperimentalTestApi
+    @Test
+    fun `undo and redo via keyboard shortcuts`() {
+        val initialText = "Hello"
+        val state = RichTextState(initialText = RichString(text = initialText))
+
+        composeTestRule.setContent {
+            RichTextEditor(state = state)
+        }
+
+        // Move cursor to the end
+        composeTestRule.onNodeWithText(initialText).performTextInputSelection(TextRange(initialText.length))
+
+        // Type " World"
+        composeTestRule.onNodeWithText(initialText).performTextInput(" World")
+        composeTestRule.waitForIdle()
+
+        val expectedNewText = "Hello World"
+        state.richString.text shouldBe expectedNewText
+
+        // Simulate Ctrl+Z (Undo)
+        composeTestRule.onNodeWithText(expectedNewText).performKeyInput {
+            keyDown(androidx.compose.ui.input.key.Key.CtrlLeft)
+            keyDown(androidx.compose.ui.input.key.Key.Z)
+            keyUp(androidx.compose.ui.input.key.Key.Z)
+            keyUp(androidx.compose.ui.input.key.Key.CtrlLeft)
+        }
+        composeTestRule.waitForIdle()
+
+        // Because " World" involves space and word, we might need two undos,
+        // but wait, `performTextInput(" World")` might be delivered as a single string replacing it.
+        // Wait, `simulateTypingAtEnd` sends char by char. `performTextInput` replaces the whole thing.
+        // Let's check what state we are in. If we just verify state.richString.text == "Hello" it's fine.
+        state.richString.text shouldBe "Hello"
+
+        // Simulate Ctrl+Shift+Z (Redo)
+        composeTestRule.onNodeWithText("Hello").performKeyInput {
+            keyDown(androidx.compose.ui.input.key.Key.CtrlLeft)
+            keyDown(androidx.compose.ui.input.key.Key.ShiftLeft)
+            keyDown(androidx.compose.ui.input.key.Key.Z)
+            keyUp(androidx.compose.ui.input.key.Key.Z)
+            keyUp(androidx.compose.ui.input.key.Key.ShiftLeft)
+            keyUp(androidx.compose.ui.input.key.Key.CtrlLeft)
+        }
+        composeTestRule.waitForIdle()
+
+        state.richString.text shouldBe "Hello World"
     }
 }

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -574,6 +574,101 @@ class RichTextStateTest {
         spans.first().range shouldBe (0..11)
         spans.first().attributes shouldBe attributeContainerOf(BulletListKey to ListIndentLevel.Level1)
     }
+
+    @Test
+    fun `canUndo is false initially`() {
+        val state = RichTextState(initialText = RichString(text = "Hello"))
+        state.canUndo shouldBe false
+        state.canRedo shouldBe false
+    }
+
+    @Test
+    fun `undo after text edit restores previous text and spans`() {
+        val state = RichTextState(initialText = RichString(text = "Hello"))
+        
+        state.simulateTypingAtEnd("World")
+        
+        state.richString.text shouldBe "HelloWorld"
+        state.canUndo shouldBe true
+        
+        state.undo()
+        state.richString.text shouldBe "Hello"
+        state.canRedo shouldBe true
+    }
+
+    @Test
+    fun `redo after undo restores text and spans`() {
+        val state = RichTextState(initialText = RichString(text = "A"))
+        state.simulateTypingAtEnd("B")
+        state.undo()
+        state.redo()
+        state.richString.text shouldBe "AB"
+    }
+
+    @Test
+    fun `continuous char input is grouped into single undo entry`() {
+        val state = RichTextState(initialText = RichString(text = ""))
+        state.simulateTypingAtEnd("a")
+        state.simulateTypingAtEnd("b")
+        state.simulateTypingAtEnd("c")
+        
+        state.undo()
+        state.richString.text shouldBe ""
+    }
+
+    @Test
+    fun `space insertion creates separate undo entry`() {
+        val state = RichTextState(initialText = RichString(text = ""))
+        state.simulateTypingAtEnd("a")
+        state.simulateTypingAtEnd("b")
+        state.simulateTypingAtEnd(" ")
+        state.simulateTypingAtEnd("c")
+        
+        state.undo()
+        // 'c' should be reverted, space and 'ab' should be kept
+        state.richString.text shouldBe "ab "
+        
+        state.undo()
+        // space should be reverted
+        state.richString.text shouldBe "ab"
+    }
+
+    @Test
+    fun `undo restores selection`() {
+        val state = RichTextState(initialText = RichString(text = "Hello"))
+        state.textFieldState.edit { selection = TextRange(2) }
+        
+        state.simulateTypingAtEnd("!") // Selection becomes 6
+        
+        state.undo()
+        state.textFieldState.selection.start shouldBe 2
+    }
+
+    @Test
+    fun `deletion always creates separate undo entry`() {
+        val state = RichTextState(initialText = RichString(text = "Hello"))
+        
+        // Simulating backspace
+        state.textFieldState.edit {
+            replace(4, 5, "")
+            selection = TextRange(4)
+            state.updateRichString(this)
+        }
+        
+        state.richString.text shouldBe "Hell"
+        state.undo()
+        state.richString.text shouldBe "Hello"
+    }
+}
+
+private fun RichTextState.simulateTypingAtEnd(text: String) {
+    for (char in text) {
+        textFieldState.edit {
+            replace(length, length, char.toString())
+            selection = TextRange(length) // move cursor
+            updateRichString(this)
+        }
+    }
 }
 
 // --- Test Helpers ---

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -584,7 +584,14 @@ class RichTextStateTest {
 
     @Test
     fun `undo after text edit restores previous text and spans`() {
-        val state = RichTextState(initialText = RichString(text = "Hello"))
+        val initialText = "Hello"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("Hello"))
+                    },
+            )
 
         state.simulateTypingAtEnd("World")
 
@@ -593,16 +600,26 @@ class RichTextStateTest {
 
         state.undoState.undo()
         state.richString.text shouldBe "Hello"
+        state.richString.spans.size shouldBe 1
+        state.richString.spans.first().range shouldBe (0..4)
+        state.richString.spans.first().attributes shouldBe attributeContainerOf(BoldKey to Unit)
         state.undoState.canRedo shouldBe true
     }
 
     @Test
     fun `redo after undo restores text and spans`() {
         val state = RichTextState(initialText = RichString(text = "A"))
+
+        state.setTypingAttribute(BoldKey, Unit)
         state.simulateTypingAtEnd("B")
+
         state.undoState.undo()
         state.undoState.redo()
+
         state.richString.text shouldBe "AB"
+        state.richString.spans.size shouldBe 1
+        state.richString.spans.first().range shouldBe (1..1) // "B" should be bold
+        state.richString.spans.first().attributes shouldBe attributeContainerOf(BoldKey to Unit)
     }
 
     @Test

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -585,12 +585,12 @@ class RichTextStateTest {
     @Test
     fun `undo after text edit restores previous text and spans`() {
         val state = RichTextState(initialText = RichString(text = "Hello"))
-        
+
         state.simulateTypingAtEnd("World")
-        
+
         state.richString.text shouldBe "HelloWorld"
         state.canUndo shouldBe true
-        
+
         state.undo()
         state.richString.text shouldBe "Hello"
         state.canRedo shouldBe true
@@ -611,7 +611,7 @@ class RichTextStateTest {
         state.simulateTypingAtEnd("a")
         state.simulateTypingAtEnd("b")
         state.simulateTypingAtEnd("c")
-        
+
         state.undo()
         state.richString.text shouldBe ""
     }
@@ -623,11 +623,11 @@ class RichTextStateTest {
         state.simulateTypingAtEnd("b")
         state.simulateTypingAtEnd(" ")
         state.simulateTypingAtEnd("c")
-        
+
         state.undo()
         // 'c' should be reverted, space and 'ab' should be kept
         state.richString.text shouldBe "ab "
-        
+
         state.undo()
         // space should be reverted
         state.richString.text shouldBe "ab"
@@ -637,9 +637,9 @@ class RichTextStateTest {
     fun `undo restores selection`() {
         val state = RichTextState(initialText = RichString(text = "Hello"))
         state.textFieldState.edit { selection = TextRange(2) }
-        
+
         state.simulateTypingAtEnd("!") // Selection becomes 6
-        
+
         state.undo()
         state.textFieldState.selection.start shouldBe 2
     }
@@ -647,14 +647,14 @@ class RichTextStateTest {
     @Test
     fun `deletion always creates separate undo entry`() {
         val state = RichTextState(initialText = RichString(text = "Hello"))
-        
+
         // Simulating backspace
         state.textFieldState.edit {
             replace(4, 5, "")
             selection = TextRange(4)
             state.updateRichString(this)
         }
-        
+
         state.richString.text shouldBe "Hell"
         state.undo()
         state.richString.text shouldBe "Hello"

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -578,8 +578,8 @@ class RichTextStateTest {
     @Test
     fun `canUndo is false initially`() {
         val state = RichTextState(initialText = RichString(text = "Hello"))
-        state.canUndo shouldBe false
-        state.canRedo shouldBe false
+        state.undoState.canUndo shouldBe false
+        state.undoState.canRedo shouldBe false
     }
 
     @Test
@@ -589,19 +589,19 @@ class RichTextStateTest {
         state.simulateTypingAtEnd("World")
 
         state.richString.text shouldBe "HelloWorld"
-        state.canUndo shouldBe true
+        state.undoState.canUndo shouldBe true
 
-        state.undo()
+        state.undoState.undo()
         state.richString.text shouldBe "Hello"
-        state.canRedo shouldBe true
+        state.undoState.canRedo shouldBe true
     }
 
     @Test
     fun `redo after undo restores text and spans`() {
         val state = RichTextState(initialText = RichString(text = "A"))
         state.simulateTypingAtEnd("B")
-        state.undo()
-        state.redo()
+        state.undoState.undo()
+        state.undoState.redo()
         state.richString.text shouldBe "AB"
     }
 
@@ -612,7 +612,7 @@ class RichTextStateTest {
         state.simulateTypingAtEnd("b")
         state.simulateTypingAtEnd("c")
 
-        state.undo()
+        state.undoState.undo()
         state.richString.text shouldBe ""
     }
 
@@ -624,11 +624,11 @@ class RichTextStateTest {
         state.simulateTypingAtEnd(" ")
         state.simulateTypingAtEnd("c")
 
-        state.undo()
+        state.undoState.undo()
         // 'c' should be reverted, space and 'ab' should be kept
         state.richString.text shouldBe "ab "
 
-        state.undo()
+        state.undoState.undo()
         // space should be reverted
         state.richString.text shouldBe "ab"
     }
@@ -640,7 +640,7 @@ class RichTextStateTest {
 
         state.simulateTypingAtEnd("!") // Selection becomes 6
 
-        state.undo()
+        state.undoState.undo()
         state.textFieldState.selection.start shouldBe 2
     }
 
@@ -656,7 +656,7 @@ class RichTextStateTest {
         }
 
         state.richString.text shouldBe "Hell"
-        state.undo()
+        state.undoState.undo()
         state.richString.text shouldBe "Hello"
     }
 }

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
@@ -11,12 +11,11 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class RichTextUndoManagerTest {
-
     private fun createSnapshot(text: String): EditorSnapshot {
         return EditorSnapshot(
             text = text,
             spans = emptyList(),
-            selection = TextRange.Zero
+            selection = TextRange.Zero,
         )
     }
 
@@ -44,7 +43,7 @@ class RichTextUndoManagerTest {
         val manager = RichTextUndoManager()
         manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
         manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.MERGE)
-        
+
         val undone = manager.undo(createSnapshot("ABC"))
         undone?.text shouldBe "AB"
     }
@@ -55,7 +54,7 @@ class RichTextUndoManagerTest {
         manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
         manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.MERGE)
         manager.pushSnapshot(createSnapshot("ABC"), UndoMergePolicy.MERGE) // Should be ignored
-        
+
         val undone = manager.undo(createSnapshot("ABCD"))
         // It pops "AB" because "ABC" was ignored
         undone?.text shouldBe "AB"
@@ -66,7 +65,7 @@ class RichTextUndoManagerTest {
         val manager = RichTextUndoManager()
         manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.MERGE)
         manager.canUndo.shouldBeTrue()
-        
+
         val undone = manager.undo(createSnapshot("AB"))
         undone?.text shouldBe "A"
     }
@@ -87,10 +86,10 @@ class RichTextUndoManagerTest {
     fun undo_movesCurrentSnapshotToRedoStack() {
         val manager = RichTextUndoManager()
         manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
-        
+
         val current = createSnapshot("2")
         manager.undo(current)
-        
+
         manager.canRedo.shouldBeTrue()
         val redone = manager.redo(createSnapshot("1"))
         redone shouldBe current
@@ -101,10 +100,10 @@ class RichTextUndoManagerTest {
         val manager = RichTextUndoManager()
         val original = createSnapshot("1")
         manager.pushSnapshot(original, UndoMergePolicy.SEPARATE)
-        
+
         val current = createSnapshot("2")
         manager.undo(current)
-        
+
         val redone = manager.redo(createSnapshot("1"))
         redone shouldBe current
     }
@@ -114,9 +113,9 @@ class RichTextUndoManagerTest {
         val manager = RichTextUndoManager()
         manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
         manager.undo(createSnapshot("2"))
-        
+
         manager.canRedo.shouldBeTrue()
-        
+
         manager.pushSnapshot(createSnapshot("3"), UndoMergePolicy.SEPARATE)
         manager.canRedo.shouldBeFalse()
     }
@@ -141,7 +140,7 @@ class RichTextUndoManagerTest {
         for (i in 1..105) {
             manager.pushSnapshot(createSnapshot(i.toString()), UndoMergePolicy.SEPARATE)
         }
-        
+
         // 100 entries should be kept, so the oldest 5 (1, 2, 3, 4, 5) are dropped.
         // We do 100 undos and the last one should be snapshot "6"
         var lastUndone: EditorSnapshot? = null
@@ -149,7 +148,7 @@ class RichTextUndoManagerTest {
         for (i in 1..100) {
             lastUndone = manager.undo(if (i == 1) current else lastUndone!!)
         }
-        
+
         lastUndone?.text shouldBe "6"
         manager.canUndo.shouldBeFalse() // Stack should be empty now
     }
@@ -159,9 +158,9 @@ class RichTextUndoManagerTest {
         val manager = RichTextUndoManager()
         manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
         manager.undo(createSnapshot("2"))
-        
+
         manager.clear()
-        
+
         manager.canUndo.shouldBeFalse()
         manager.canRedo.shouldBeFalse()
     }

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
@@ -146,7 +146,8 @@ class RichTextUndoManagerTest {
         var lastUndone: EditorSnapshot? = null
         val current = createSnapshot("106")
         for (i in 1..100) {
-            lastUndone = manager.undo(if (i == 1) current else lastUndone!!)
+            val prev = if (i == 1) current else requireNotNull(lastUndone) { "undo stack exhausted earlier than expected" }
+            lastUndone = manager.undo(prev)
         }
 
         lastUndone?.text shouldBe "6"

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
@@ -20,40 +20,40 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun canUndo_returnsFalse_whenStackIsEmpty() {
+    fun `canUndo returns false when stack is empty`() {
         val manager = RichTextUndoManager()
         manager.canUndo.shouldBeFalse()
     }
 
     @Test
-    fun canRedo_returnsFalse_whenStackIsEmpty() {
+    fun `canRedo returns false when stack is empty`() {
         val manager = RichTextUndoManager()
         manager.canRedo.shouldBeFalse()
     }
 
     @Test
-    fun pushSnapshot_SEPARATE_makesCanUndoTrue() {
+    fun `pushSnapshot with Separate makes canUndo true`() {
         val manager = RichTextUndoManager()
-        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.Separate)
         manager.canUndo.shouldBeTrue()
     }
 
     @Test
-    fun pushSnapshot_MERGE_addsNewEntryIfLastWasSeparate() {
+    fun `pushSnapshot with Merge adds new entry if last was Separate`() {
         val manager = RichTextUndoManager()
-        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
-        manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.MERGE)
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.Separate)
+        manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.Merge)
 
         val undone = manager.undo(createSnapshot("ABC"))
         undone?.text shouldBe "AB"
     }
 
     @Test
-    fun pushSnapshot_MERGE_ignoresIfLastWasMerge() {
+    fun `pushSnapshot with Merge ignores if last was Merge`() {
         val manager = RichTextUndoManager()
-        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
-        manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.MERGE)
-        manager.pushSnapshot(createSnapshot("ABC"), UndoMergePolicy.MERGE) // Should be ignored
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.Separate)
+        manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.Merge)
+        manager.pushSnapshot(createSnapshot("ABC"), UndoMergePolicy.Merge) // Should be ignored
 
         val undone = manager.undo(createSnapshot("ABCD"))
         // It pops "AB" because "ABC" was ignored
@@ -61,9 +61,9 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun pushSnapshot_MERGE_onEmptyStack_addsEntry() {
+    fun `pushSnapshot with Merge on empty stack adds entry`() {
         val manager = RichTextUndoManager()
-        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.MERGE)
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.Merge)
         manager.canUndo.shouldBeTrue()
 
         val undone = manager.undo(createSnapshot("AB"))
@@ -71,21 +71,21 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun undo_returnsTheLastPushedSnapshot() {
+    fun `undo returns the last pushed snapshot`() {
         val manager = RichTextUndoManager()
         val snapshot1 = createSnapshot("1")
         val snapshot2 = createSnapshot("2")
-        manager.pushSnapshot(snapshot1, UndoMergePolicy.SEPARATE)
-        manager.pushSnapshot(snapshot2, UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(snapshot1, UndoMergePolicy.Separate)
+        manager.pushSnapshot(snapshot2, UndoMergePolicy.Separate)
 
         val undone = manager.undo(createSnapshot("3"))
         undone shouldBe snapshot2
     }
 
     @Test
-    fun undo_movesCurrentSnapshotToRedoStack() {
+    fun `undo moves current snapshot to redo stack`() {
         val manager = RichTextUndoManager()
-        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.Separate)
 
         val current = createSnapshot("2")
         manager.undo(current)
@@ -96,10 +96,10 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun redo_returnsTheUndoneSnapshot() {
+    fun `redo returns the undone snapshot`() {
         val manager = RichTextUndoManager()
         val original = createSnapshot("1")
-        manager.pushSnapshot(original, UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(original, UndoMergePolicy.Separate)
 
         val current = createSnapshot("2")
         manager.undo(current)
@@ -109,36 +109,36 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun pushAfterUndo_clearsRedoStack() {
+    fun `push after undo clears redo stack`() {
         val manager = RichTextUndoManager()
-        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.Separate)
         manager.undo(createSnapshot("2"))
 
         manager.canRedo.shouldBeTrue()
 
-        manager.pushSnapshot(createSnapshot("3"), UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(createSnapshot("3"), UndoMergePolicy.Separate)
         manager.canRedo.shouldBeFalse()
     }
 
     @Test
-    fun undo_returnsNull_whenStackIsEmpty() {
+    fun `undo returns null when stack is empty`() {
         val manager = RichTextUndoManager()
         val undone = manager.undo(createSnapshot("1"))
         undone.shouldBeNull()
     }
 
     @Test
-    fun redo_returnsNull_whenStackIsEmpty() {
+    fun `redo returns null when stack is empty`() {
         val manager = RichTextUndoManager()
         val redone = manager.redo(createSnapshot("1"))
         redone.shouldBeNull()
     }
 
     @Test
-    fun stackIsCappedAtMaxSize() {
+    fun `stack is capped at maxSize`() {
         val manager = RichTextUndoManager()
         for (i in 1..105) {
-            manager.pushSnapshot(createSnapshot(i.toString()), UndoMergePolicy.SEPARATE)
+            manager.pushSnapshot(createSnapshot(i.toString()), UndoMergePolicy.Separate)
         }
 
         // 100 entries should be kept, so the oldest 5 (1, 2, 3, 4, 5) are dropped.
@@ -154,9 +154,9 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun clear_resetsBothStacks() {
+    fun `clear resets both stacks`() {
         val manager = RichTextUndoManager()
-        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.Separate)
         manager.undo(createSnapshot("2"))
 
         manager.clear()

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
@@ -40,7 +40,7 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun pushSnapshot_MERGE_overwritesTopEntry() {
+    fun pushSnapshot_MERGE_addsNewEntryIfLastWasSeparate() {
         val manager = RichTextUndoManager()
         manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
         manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.MERGE)
@@ -50,7 +50,19 @@ class RichTextUndoManagerTest {
     }
 
     @Test
-    fun pushSnapshot_MERGE_onEmptyStack_behavesAsSEPARATE() {
+    fun pushSnapshot_MERGE_ignoresIfLastWasMerge() {
+        val manager = RichTextUndoManager()
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.MERGE)
+        manager.pushSnapshot(createSnapshot("ABC"), UndoMergePolicy.MERGE) // Should be ignored
+        
+        val undone = manager.undo(createSnapshot("ABCD"))
+        // It pops "AB" because "ABC" was ignored
+        undone?.text shouldBe "AB"
+    }
+
+    @Test
+    fun pushSnapshot_MERGE_onEmptyStack_addsEntry() {
         val manager = RichTextUndoManager()
         manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.MERGE)
         manager.canUndo.shouldBeTrue()

--- a/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
+++ b/richtext-editor/src/test/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextUndoManagerTest.kt
@@ -1,0 +1,156 @@
+package dev.mkeeda.arranger.richtext.editor
+
+import androidx.compose.ui.text.TextRange
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RichTextUndoManagerTest {
+
+    private fun createSnapshot(text: String): EditorSnapshot {
+        return EditorSnapshot(
+            text = text,
+            spans = emptyList(),
+            selection = TextRange.Zero
+        )
+    }
+
+    @Test
+    fun canUndo_returnsFalse_whenStackIsEmpty() {
+        val manager = RichTextUndoManager()
+        manager.canUndo.shouldBeFalse()
+    }
+
+    @Test
+    fun canRedo_returnsFalse_whenStackIsEmpty() {
+        val manager = RichTextUndoManager()
+        manager.canRedo.shouldBeFalse()
+    }
+
+    @Test
+    fun pushSnapshot_SEPARATE_makesCanUndoTrue() {
+        val manager = RichTextUndoManager()
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
+        manager.canUndo.shouldBeTrue()
+    }
+
+    @Test
+    fun pushSnapshot_MERGE_overwritesTopEntry() {
+        val manager = RichTextUndoManager()
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(createSnapshot("AB"), UndoMergePolicy.MERGE)
+        
+        val undone = manager.undo(createSnapshot("ABC"))
+        undone?.text shouldBe "AB"
+    }
+
+    @Test
+    fun pushSnapshot_MERGE_onEmptyStack_behavesAsSEPARATE() {
+        val manager = RichTextUndoManager()
+        manager.pushSnapshot(createSnapshot("A"), UndoMergePolicy.MERGE)
+        manager.canUndo.shouldBeTrue()
+        
+        val undone = manager.undo(createSnapshot("AB"))
+        undone?.text shouldBe "A"
+    }
+
+    @Test
+    fun undo_returnsTheLastPushedSnapshot() {
+        val manager = RichTextUndoManager()
+        val snapshot1 = createSnapshot("1")
+        val snapshot2 = createSnapshot("2")
+        manager.pushSnapshot(snapshot1, UndoMergePolicy.SEPARATE)
+        manager.pushSnapshot(snapshot2, UndoMergePolicy.SEPARATE)
+
+        val undone = manager.undo(createSnapshot("3"))
+        undone shouldBe snapshot2
+    }
+
+    @Test
+    fun undo_movesCurrentSnapshotToRedoStack() {
+        val manager = RichTextUndoManager()
+        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
+        
+        val current = createSnapshot("2")
+        manager.undo(current)
+        
+        manager.canRedo.shouldBeTrue()
+        val redone = manager.redo(createSnapshot("1"))
+        redone shouldBe current
+    }
+
+    @Test
+    fun redo_returnsTheUndoneSnapshot() {
+        val manager = RichTextUndoManager()
+        val original = createSnapshot("1")
+        manager.pushSnapshot(original, UndoMergePolicy.SEPARATE)
+        
+        val current = createSnapshot("2")
+        manager.undo(current)
+        
+        val redone = manager.redo(createSnapshot("1"))
+        redone shouldBe current
+    }
+
+    @Test
+    fun pushAfterUndo_clearsRedoStack() {
+        val manager = RichTextUndoManager()
+        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
+        manager.undo(createSnapshot("2"))
+        
+        manager.canRedo.shouldBeTrue()
+        
+        manager.pushSnapshot(createSnapshot("3"), UndoMergePolicy.SEPARATE)
+        manager.canRedo.shouldBeFalse()
+    }
+
+    @Test
+    fun undo_returnsNull_whenStackIsEmpty() {
+        val manager = RichTextUndoManager()
+        val undone = manager.undo(createSnapshot("1"))
+        undone.shouldBeNull()
+    }
+
+    @Test
+    fun redo_returnsNull_whenStackIsEmpty() {
+        val manager = RichTextUndoManager()
+        val redone = manager.redo(createSnapshot("1"))
+        redone.shouldBeNull()
+    }
+
+    @Test
+    fun stackIsCappedAtMaxSize() {
+        val manager = RichTextUndoManager()
+        for (i in 1..105) {
+            manager.pushSnapshot(createSnapshot(i.toString()), UndoMergePolicy.SEPARATE)
+        }
+        
+        // 100 entries should be kept, so the oldest 5 (1, 2, 3, 4, 5) are dropped.
+        // We do 100 undos and the last one should be snapshot "6"
+        var lastUndone: EditorSnapshot? = null
+        val current = createSnapshot("106")
+        for (i in 1..100) {
+            lastUndone = manager.undo(if (i == 1) current else lastUndone!!)
+        }
+        
+        lastUndone?.text shouldBe "6"
+        manager.canUndo.shouldBeFalse() // Stack should be empty now
+    }
+
+    @Test
+    fun clear_resetsBothStacks() {
+        val manager = RichTextUndoManager()
+        manager.pushSnapshot(createSnapshot("1"), UndoMergePolicy.SEPARATE)
+        manager.undo(createSnapshot("2"))
+        
+        manager.clear()
+        
+        manager.canUndo.shouldBeFalse()
+        manager.canRedo.shouldBeFalse()
+    }
+}


### PR DESCRIPTION
## Overview
This pull request integrates the Undo/Redo engine into `RichTextEditor` and refactors its architecture by separating responsibilities into standalone components. It addresses the growing complexity of `RichTextState` and `RichTextEditor` by decoupling the undo/redo functionality and extracting internal transformations into dedicated files.

## Implementation Details
- **Undo/Redo Engine Integration**: 
  - Implemented `RichTextUndoManager` to automatically capture and restore snapshots containing text, spans, and selection states during typing.
  - Added support for standard keyboard shortcuts: `Cmd/Ctrl + Z` (Undo) and `Cmd/Ctrl + Shift + Z` (Redo).
  - Defined `UndoMergePolicy` to intelligently merge consecutive single-character typings, while isolating whitespace, newlines, deletions, and multi-character pastes into distinct undo steps.
- **State Decoupling**: 
  - Extracted `RichTextUndoState` as an independent class. This completely decouples snapshot capturing, restoring, and merge policy logic from `RichTextState`, utilizing a loosely-coupled callback design.
- **UI Component Refactoring**:
  - Extracted multiple internal classes out of `RichTextEditor.kt` into their own files to improve readability and maintainability:
    - `ComposeParagraphWorkarounds.kt`: Encapsulates Compose paragraph boundary workarounds.
    - `RichTextOutputTransformation.kt`: Handles visual styling applications.
    - `RichTextInputTransformation.kt`: Handles input text synchronization.
    - `RichTextKeyboardShortcuts.kt`: Extracts keyboard shortcut handling as a `Modifier` extension.
- **Code Style & Documentation**:
  - Added English KDocs to public undo/redo APIs detailing the snapshot granularity policy.
  - Enforced project code style guidelines (e.g., UpperCamelCase for enum constants, backtick-enclosed unit test names) and applied Spotless formatting.