### PR TITLE
chore(release): bump version to 0.2.0-alpha05

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Arranger is published to Maven Central. Add the following dependencies to your m
 dependencies {
     // For Compose UI integration (RichTextEditor).
     // This automatically includes the core 'arranger-richtext' module.
-    implementation("dev.mkeeda.arranger:arranger-richtext-editor:0.2.0-alpha04")
+    implementation("dev.mkeeda.arranger:arranger-richtext-editor:0.2.0-alpha05")
 
     // Or, if you only need the core data structures without Compose UI:
-    // implementation("dev.mkeeda.arranger:arranger-richtext:0.2.0-alpha04")
+    // implementation("dev.mkeeda.arranger:arranger-richtext:0.2.0-alpha05")
 }
 ```
 
@@ -340,7 +340,7 @@ You can define custom attribute keys and map them to Compose styles. Below shows
 > To use it, add the following dependency to your module's `build.gradle.kts`:
 > ```kotlin
 > dependencies {
->     implementation("dev.mkeeda.arranger:arranger-richtext-editor-material3:0.2.0-alpha04")
+>     implementation("dev.mkeeda.arranger:arranger-richtext-editor-material3:0.2.0-alpha05")
 > }
 > ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ kotlin.code.style=official
 
 # Maven Central publishing
 GROUP=dev.mkeeda.arranger
-VERSION_NAME=0.2.0-alpha04
+VERSION_NAME=0.2.0-alpha05
 POM_URL=https://github.com/mkeeda/arranger/
 POM_LICENSE_NAME=Apache-2.0
 POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
This PR prepares the release for version `v0.2.0-alpha05`.

- Updates version in `gradle.properties`
- Updates dependency versions in `README.md`