### PR TITLE
build: use JavadocJar.Empty() to satisfy Sonatype validation

### DIFF
--- a/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
@@ -19,7 +19,7 @@ class MavenPublishConventionPlugin : Plugin<Project> {
                 //   - IDE quick-docs work fine via the sources jar.
                 // TODO: Re-enable javadoc generation once migrating to Dokka K2 engine.
                 pluginManager.withPlugin("com.android.kotlin.multiplatform.library") {
-                    configure(KotlinMultiplatform(javadocJar = JavadocJar.None()))
+                    configure(KotlinMultiplatform(javadocJar = JavadocJar.Empty()))
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/MavenPublishConventionPlugin.kt
@@ -14,9 +14,8 @@ class MavenPublishConventionPlugin : Plugin<Project> {
                 publishToMavenCentral()
                 // Dokka (K1 engine) fails to resolve opt-in annotation markers (e.g., @InternalArrangerApi)
                 // used in richtext-editor, causing the javadoc generation task to crash.
-                // JavadocJar.None() skips javadoc jar generation, which is acceptable because:
-                //   - Maven Central (Central Portal) does not require a javadoc jar.
-                //   - IDE quick-docs work fine via the sources jar.
+                // JavadocJar.Empty() generates an empty javadoc jar to satisfy Maven Central validation.
+                // IDE quick-docs work fine via the sources jar.
                 // TODO: Re-enable javadoc generation once migrating to Dokka K2 engine.
                 pluginManager.withPlugin("com.android.kotlin.multiplatform.library") {
                     configure(KotlinMultiplatform(javadocJar = JavadocJar.Empty()))


### PR DESCRIPTION
This fixes an issue where Sonatype deployment validation failed because Javadocs were not provided for JVM artifacts. By using `JavadocJar.Empty()` instead of `JavadocJar.None()`, we ensure an empty `-javadoc.jar` is generated and published, which satisfies Maven Central's validation requirements.