### PR TITLE
fix(sample): enable Android resources in KMP and add UI tests

### DIFF
--- a/build-logic/convention/src/main/kotlin/dev/mkeeda/arranger/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/dev/mkeeda/arranger/buildlogic/KotlinAndroid.kt
@@ -13,6 +13,8 @@ internal fun Project.configureAndroidTarget(
     (extension as ExtensionAware).extensions.configure("android", Action<KotlinMultiplatformAndroidLibraryExtension> {
         compileSdk = 37
         minSdk = 26
+        @Suppress("UnstableApiUsage")
+        experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true
     })
 }
 

--- a/sample/android/src/main/java/dev/mkeeda/arranger/sampleApp/MainActivity.kt
+++ b/sample/android/src/main/java/dev/mkeeda/arranger/sampleApp/MainActivity.kt
@@ -49,10 +49,10 @@ import dev.mkeeda.arranger.sample.shared.theme.ArrangerTheme
 import kotlinx.serialization.Serializable
 
 @Serializable
-private data object SampleList : NavKey
+internal data object SampleList : NavKey
 
 @Serializable
-private enum class SampleDestination(val title: String) : NavKey {
+internal enum class SampleDestination(val title: String) : NavKey {
     DynamicEditing("Dynamic Editing"),
     AdvancedFormatting("Advanced Formatting"),
     CustomAttribute("Custom Attribute"),

--- a/sample/android/src/test/java/dev/mkeeda/arranger/sampleApp/MainActivityTest.kt
+++ b/sample/android/src/test/java/dev/mkeeda/arranger/sampleApp/MainActivityTest.kt
@@ -1,0 +1,32 @@
+package dev.mkeeda.arranger.sampleApp
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun `Navigate to all sample screens`() {
+        SampleDestination.entries.forEach { destination ->
+            composeTestRule.onNode(hasScrollAction()).performScrollToNode(hasText(destination.title))
+            composeTestRule.onNodeWithText(destination.title).performClick()
+
+            val backButton = composeTestRule.onNodeWithContentDescription("back")
+            backButton.assertIsDisplayed()
+            backButton.performClick()
+        }
+    }
+}

--- a/sample/android/src/test/resources/robolectric.properties
+++ b/sample/android/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+sdk=36
+graphicsMode=NATIVE


### PR DESCRIPTION
## Overview
This PR fixes the `MissingResourceException` that occurred when running the Android sample application (`sample:android`). The crash was caused by the Compose Multiplatform resources not being correctly packaged and shared with the Android module.

## Implementation Details
- **Enabled Android resources in KMP**: Updated `KotlinAndroid.kt` to include `experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true`. This ensures that resources generated by Compose Multiplatform in the shared module are correctly propagated to the Android target.
- **Added UI Tests**: Added a standard Compose UI Test (`MainActivityTest.kt`) to verify that all sample destinations load correctly. The test iterates through all screens in `SampleDestination.entries` and ensures they can be navigated to without crashing.