### PR TITLE
fix(desktop): prevent format toolbar buttons from stealing focus

### DIFF
--- a/sample/desktop/build.gradle.kts
+++ b/sample/desktop/build.gradle.kts
@@ -16,6 +16,14 @@ kotlin {
                 implementation(compose.ui)
             }
         }
+        val jvmTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+                implementation(compose.desktop.uiTestJUnit4)
+            }
+        }
     }
 }
 

--- a/sample/desktop/src/jvmTest/kotlin/dev/mkeeda/arranger/sample/desktop/DocumentEditorDesktopTest.kt
+++ b/sample/desktop/src/jvmTest/kotlin/dev/mkeeda/arranger/sample/desktop/DocumentEditorDesktopTest.kt
@@ -1,0 +1,46 @@
+package dev.mkeeda.arranger.sample.desktop
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextInputSelection
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.TextRange
+import dev.mkeeda.arranger.sample.shared.DocumentEditorSample
+import dev.mkeeda.arranger.sample.shared.theme.ArrangerTheme
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DocumentEditorDesktopTest {
+
+    @Test
+    fun `toolbar buttons apply format to selected text on desktop`() = runComposeUiTest {
+        setContent {
+            ArrangerTheme {
+                DocumentEditorSample()
+            }
+        }
+
+        val textInputNode = onNodeWithTag("DocumentEditor")
+        textInputNode.performTextInput("Desktop Test")
+
+        // Select "Desktop Test"
+        textInputNode.performTextInputSelection(TextRange(0, 12))
+        textInputNode.assertIsFocused()
+
+        // Toggle Bold on
+        // Assert initial state
+        onNodeWithContentDescription("Bold").assertIsOff()
+
+        onNodeWithContentDescription("Bold").performClick()
+        
+        // Assert Bold is applied (button remains toggled ON after click)
+        onNodeWithContentDescription("Bold").assertIsOn()
+        textInputNode.assertIsFocused()
+    }
+}

--- a/sample/desktop/src/jvmTest/kotlin/dev/mkeeda/arranger/sample/desktop/DocumentEditorDesktopTest.kt
+++ b/sample/desktop/src/jvmTest/kotlin/dev/mkeeda/arranger/sample/desktop/DocumentEditorDesktopTest.kt
@@ -33,13 +33,13 @@ class DocumentEditorDesktopTest {
         textInputNode.performTextInputSelection(TextRange(0, 12))
         textInputNode.assertIsFocused()
 
-        // Toggle Bold on
-        // Assert initial state
+        // Assert initial state (Bold is OFF)
         onNodeWithContentDescription("Bold").assertIsOff()
 
+        // Toggle Bold on
         onNodeWithContentDescription("Bold").performClick()
-        
-        // Assert Bold is applied (button remains toggled ON after click)
+
+        // Assert Bold is applied (button remains toggled ON)
         onNodeWithContentDescription("Bold").assertIsOn()
         textInputNode.assertIsFocused()
     }

--- a/sample/shared/src/commonMain/kotlin/dev/mkeeda/arranger/sample/shared/DocumentEditorSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/mkeeda/arranger/sample/shared/DocumentEditorSample.kt
@@ -271,7 +271,8 @@ private fun DocumentFormattingToolbar(
             modifier = unfocusableModifier,
         )
 
-        IndentOutdentButtons(state = state, modifier = unfocusableModifier)
+        OutdentButton(state = state, modifier = unfocusableModifier)
+        IndentButton(state = state, modifier = unfocusableModifier)
 
         Spacer(modifier = Modifier.weight(1f))
 
@@ -346,7 +347,7 @@ private fun DocumentEditorField(state: RichTextState, modifier: Modifier = Modif
 }
 
 @Composable
-private fun IndentOutdentButtons(
+private fun OutdentButton(
     state: RichTextState,
     modifier: Modifier = Modifier,
 ) {
@@ -375,7 +376,13 @@ private fun IndentOutdentButtons(
             contentDescription = "Outdent",
         )
     }
+}
 
+@Composable
+private fun IndentButton(
+    state: RichTextState,
+    modifier: Modifier = Modifier,
+) {
     IconButton(
         onClick = {
             val currentLevel =

--- a/sample/shared/src/commonMain/kotlin/dev/mkeeda/arranger/sample/shared/DocumentEditorSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/mkeeda/arranger/sample/shared/DocumentEditorSample.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import dev.mkeeda.arranger.richtext.BackgroundColorKey
@@ -113,6 +114,7 @@ private fun DocumentFormattingToolbar(
     state: RichTextState,
     modifier: Modifier = Modifier,
 ) {
+    val unfocusableModifier = Modifier.focusProperties { canFocus = false }
     FlowRow(
         modifier =
             modifier
@@ -123,6 +125,7 @@ private fun DocumentFormattingToolbar(
         IconButton(
             onClick = { state.undoState.undo() },
             enabled = state.undoState.canUndo,
+            modifier = unfocusableModifier,
         ) {
             Icon(
                 painter = painterResource(Res.drawable.undo),
@@ -132,6 +135,7 @@ private fun DocumentFormattingToolbar(
         IconButton(
             onClick = { state.undoState.redo() },
             enabled = state.undoState.canRedo,
+            modifier = unfocusableModifier,
         ) {
             Icon(
                 painter = painterResource(Res.drawable.redo),
@@ -145,24 +149,28 @@ private fun DocumentFormattingToolbar(
             contentDescription = "Bold",
             isActive = state.currentAttributes.containsKey(BoldKey),
             onClick = { state.toggleFormat(BoldKey) },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_italic,
             contentDescription = "Italic",
             isActive = state.currentAttributes.containsKey(ItalicKey),
             onClick = { state.toggleFormat(ItalicKey) },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_underlined,
             contentDescription = "Underline",
             isActive = state.currentAttributes.containsKey(UnderlineKey),
             onClick = { state.toggleFormat(UnderlineKey) },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_strikethrough,
             contentDescription = "Strikethrough",
             isActive = state.currentAttributes.containsKey(StrikethroughKey),
             onClick = { state.toggleFormat(StrikethroughKey) },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_color_text,
@@ -175,6 +183,7 @@ private fun DocumentFormattingToolbar(
                     state.applyFormat(TextColorKey, RgbaColor(0xFFFF0000))
                 }
             },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_color_fill,
@@ -187,6 +196,7 @@ private fun DocumentFormattingToolbar(
                     state.applyFormat(BackgroundColorKey, RgbaColor(0xFFFFFF00))
                 }
             },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_size,
@@ -199,6 +209,7 @@ private fun DocumentFormattingToolbar(
                     state.applyFormat(FontSizeKey, TextSize(24f))
                 }
             },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_h1,
@@ -211,6 +222,7 @@ private fun DocumentFormattingToolbar(
                     state.applyFormat(HeadingKey, HeadingLevel.H1)
                 }
             },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_align_center,
@@ -223,12 +235,14 @@ private fun DocumentFormattingToolbar(
                     state.applyFormat(TextAlignmentKey, TextAlignment.Center)
                 }
             },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_quote,
             contentDescription = "Blockquote",
             isActive = state.currentAttributes.containsKey(BlockquoteKey),
             onClick = { state.toggleFormat(BlockquoteKey) },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_list_bulleted,
@@ -241,6 +255,7 @@ private fun DocumentFormattingToolbar(
                     state.applyFormat(BulletListKey, ListIndentLevel.Level1)
                 }
             },
+            modifier = unfocusableModifier,
         )
         FormatToggleButton(
             iconRes = Res.drawable.format_list_numbered,
@@ -253,15 +268,17 @@ private fun DocumentFormattingToolbar(
                     state.applyFormat(OrderedListKey, ListIndentLevel.Level1)
                 }
             },
+            modifier = unfocusableModifier,
         )
 
-        IndentOutdentButtons(state = state)
+        IndentOutdentButtons(state = state, modifier = unfocusableModifier)
 
         Spacer(modifier = Modifier.weight(1f))
 
         IconButton(
             onClick = { state.clearFormats() },
             enabled = true,
+            modifier = unfocusableModifier,
         ) {
             Icon(
                 painter = painterResource(Res.drawable.format_clear),
@@ -277,6 +294,7 @@ private fun FormatToggleButton(
     contentDescription: String,
     isActive: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val colors =
         IconButtonDefaults.iconToggleButtonColors(
@@ -288,6 +306,7 @@ private fun FormatToggleButton(
         onCheckedChange = { onClick() },
         enabled = true,
         colors = colors,
+        modifier = modifier,
     ) {
         Icon(
             painter = painterResource(iconRes),


### PR DESCRIPTION
## Overview
Fixed a bug in the desktop sample app where clicking formatting toolbar buttons (such as Bold, Italic) caused the `DocumentEditor` to lose text selection focus, preventing the format attributes from being applied to the selected text.

## Implementation Details
- Applied `Modifier.focusProperties { canFocus = false }` to all format toggle buttons and icon buttons in the `DocumentFormattingToolbar` within `DocumentEditorSample.kt`.
- Added a new desktop E2E test `DocumentEditorDesktopTest.kt` in `sample:desktop` to verify that the format buttons can be clicked without stealing focus from the `RichTextEditor`.