### PR TITLE
fix(richtext): narrow diff on IME text replacements to prevent span leak

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/sample/ios/ArrangerSample" vcs="Git" />
   </component>
 </project>

--- a/richtext-editor/src/commonMain/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/commonMain/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -244,37 +244,15 @@ public class RichTextState(initialText: RichString = RichString("")) {
 
         val newSpans =
             (0 until buffer.changes.changeCount).fold(spans) { currentSpans, i ->
-                val rawOriginalRange = buffer.changes.getOriginalRange(i)
-                val rawRange = buffer.changes.getRange(i)
-                val originalStr = buffer.originalText.substring(rawOriginalRange.min, rawOriginalRange.max)
-                val newStr = buffer.asCharSequence().substring(rawRange.min, rawRange.max)
-
-                // Narrow down the delta by finding the common prefix and suffix
-                var prefixLength = 0
-                val minLength = minOf(originalStr.length, newStr.length)
-                while (prefixLength < minLength && originalStr[prefixLength] == newStr[prefixLength]) {
-                    prefixLength++
-                }
-
-                var suffixLength = 0
-                val maxSuffixLength = minLength - prefixLength
-                while (
-                    suffixLength < maxSuffixLength &&
-                    originalStr[originalStr.length - 1 - suffixLength] == newStr[newStr.length - 1 - suffixLength]
-                ) {
-                    suffixLength++
-                }
-
-                val originalRange =
-                    TextRange(
-                        rawOriginalRange.min + prefixLength,
-                        rawOriginalRange.max - suffixLength,
+                val delta =
+                    getNarrowedDelta(
+                        originalText = buffer.originalText,
+                        newText = buffer.asCharSequence(),
+                        rawOriginalRange = buffer.changes.getOriginalRange(i),
+                        rawRange = buffer.changes.getRange(i),
                     )
-                val range =
-                    TextRange(
-                        rawRange.min + prefixLength,
-                        rawRange.max - suffixLength,
-                    )
+                val originalRange = delta.originalRange
+                val range = delta.range
 
                 var updatedSpans =
                     currentSpans.shiftSpans(
@@ -562,4 +540,44 @@ private fun shiftSpan(
             }
         }
     }
+}
+
+private data class ChangeDelta(
+    val originalRange: TextRange,
+    val range: TextRange,
+)
+
+private fun getNarrowedDelta(
+    originalText: CharSequence,
+    newText: CharSequence,
+    rawOriginalRange: TextRange,
+    rawRange: TextRange,
+): ChangeDelta {
+    val origStart = rawOriginalRange.min
+    val origEnd = rawOriginalRange.max
+    val newStart = rawRange.min
+    val newEnd = rawRange.max
+
+    val origLen = origEnd - origStart
+    val newLen = newEnd - newStart
+    val minLength = minOf(origLen, newLen)
+
+    var prefixLength = 0
+    while (prefixLength < minLength && originalText[origStart + prefixLength] == newText[newStart + prefixLength]) {
+        prefixLength++
+    }
+
+    var suffixLength = 0
+    val maxSuffixLength = minLength - prefixLength
+    while (
+        suffixLength < maxSuffixLength &&
+        originalText[origEnd - 1 - suffixLength] == newText[newEnd - 1 - suffixLength]
+    ) {
+        suffixLength++
+    }
+
+    return ChangeDelta(
+        originalRange = TextRange(origStart + prefixLength, origEnd - suffixLength),
+        range = TextRange(newStart + prefixLength, newEnd - suffixLength),
+    )
 }

--- a/richtext-editor/src/commonMain/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
+++ b/richtext-editor/src/commonMain/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextState.kt
@@ -244,8 +244,37 @@ public class RichTextState(initialText: RichString = RichString("")) {
 
         val newSpans =
             (0 until buffer.changes.changeCount).fold(spans) { currentSpans, i ->
-                val originalRange = buffer.changes.getOriginalRange(i)
-                val range = buffer.changes.getRange(i)
+                val rawOriginalRange = buffer.changes.getOriginalRange(i)
+                val rawRange = buffer.changes.getRange(i)
+                val originalStr = buffer.originalText.substring(rawOriginalRange.min, rawOriginalRange.max)
+                val newStr = buffer.asCharSequence().substring(rawRange.min, rawRange.max)
+
+                // Narrow down the delta by finding the common prefix and suffix
+                var prefixLength = 0
+                val minLength = minOf(originalStr.length, newStr.length)
+                while (prefixLength < minLength && originalStr[prefixLength] == newStr[prefixLength]) {
+                    prefixLength++
+                }
+
+                var suffixLength = 0
+                val maxSuffixLength = minLength - prefixLength
+                while (
+                    suffixLength < maxSuffixLength &&
+                    originalStr[originalStr.length - 1 - suffixLength] == newStr[newStr.length - 1 - suffixLength]
+                ) {
+                    suffixLength++
+                }
+
+                val originalRange =
+                    TextRange(
+                        rawOriginalRange.min + prefixLength,
+                        rawOriginalRange.max - suffixLength,
+                    )
+                val range =
+                    TextRange(
+                        rawRange.min + prefixLength,
+                        rawRange.max - suffixLength,
+                    )
 
                 var updatedSpans =
                     currentSpans.shiftSpans(

--- a/richtext-editor/src/commonTest/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/commonTest/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -676,6 +676,146 @@ class RichTextStateTest {
         state.undoState.undo()
         state.richString.text shouldBe "Hello"
     }
+
+    @Test
+    fun `IME word replacement correctly narrows span expansion`() {
+        val initialText = "qwertyui"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("ertyui"))
+                    },
+            )
+
+        // Select the end
+        state.textFieldState.edit {
+            selection = TextRange(initialText.length)
+        }
+
+        // Toggle OFF Bold
+        state.removeTypingAttribute(BoldKey)
+
+        // iOS IME replaces the entire word
+        state.textFieldState.edit {
+            replace(0, 8, "qwertyuiredf")
+            selection = TextRange(12)
+            state.updateRichString(this)
+        }
+
+        val expectedText = "qwertyuiredf"
+        state.richString.text shouldBe expectedText
+
+        val spans = state.richString.spans
+        spans.size shouldBe 1
+        // The span for "ertyui" (2..7) should remain unchanged because the actual insertion was at the end
+        spans.first().range shouldBe (2..7)
+        spans.first().attributes shouldBe attributeContainerOf(BoldKey to Unit)
+    }
+
+    @Test
+    fun `IME Return key replacement triggers EnterKeyStrategy`() {
+        val initialText = "Heading"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setParagraphAttribute(
+                            dev.mkeeda.arranger.richtext.HeadingKey,
+                            dev.mkeeda.arranger.richtext.HeadingLevel.H1,
+                            range = initialText.indices,
+                        )
+                    },
+            )
+
+        // Move to the end
+        state.textFieldState.edit {
+            selection = TextRange(initialText.length)
+        }
+
+        // iOS IME replaces the whole word with "Heading\n"
+        state.textFieldState.edit {
+            replace(0, 7, "Heading\n")
+            selection = TextRange(8)
+            state.updateRichString(this)
+        }
+
+        val expectedText = "Heading\n"
+        state.richString.text shouldBe expectedText
+
+        val spans = state.richString.spans
+        spans.size shouldBe 1
+        // The Heading should only apply to the first paragraph (0..7), not the new empty paragraph
+        spans.first().range shouldBe (0..7)
+    }
+
+    @Test
+    fun `Pasting text with newlines over matching prefix falls back to paragraph inheritance`() {
+        val initialText = "Heading"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setParagraphAttribute(
+                            dev.mkeeda.arranger.richtext.HeadingKey,
+                            dev.mkeeda.arranger.richtext.HeadingLevel.H1,
+                            range = initialText.indices,
+                        )
+                    },
+            )
+
+        // Select the end
+        state.textFieldState.edit {
+            selection = TextRange(initialText.length)
+        }
+
+        // Paste "Heading\nNew Paragraph" over "Heading"
+        state.textFieldState.edit {
+            replace(0, 7, "Heading\nNew Paragraph")
+            selection = TextRange(21)
+            state.updateRichString(this)
+        }
+
+        val expectedText = "Heading\nNew Paragraph"
+        state.richString.text shouldBe expectedText
+
+        val spans = state.richString.spans
+        spans.size shouldBe 1
+        // Since it's a multi-character paste with a newline, the paragraph attribute should inherit to both lines
+        spans.first().range shouldBe (0..21)
+        spans.first().attributes shouldBe
+            attributeContainerOf(
+                dev.mkeeda.arranger.richtext.HeadingKey to dev.mkeeda.arranger.richtext.HeadingLevel.H1,
+            )
+    }
+
+    @Test
+    fun `Pasting text over matching prefix and suffix replaces only the delta`() {
+        val initialText = "abc"
+        val state =
+            RichTextState(
+                initialText =
+                    RichString(text = initialText).edit {
+                        setSpanAttribute(BoldKey, Unit, range = initialText.rangeOf("b"))
+                    },
+            )
+
+        // Paste "axc" over "abc"
+        state.textFieldState.edit {
+            replace(0, 3, "axc")
+            selection = TextRange(3)
+            state.updateRichString(this)
+        }
+
+        val expectedText = "axc"
+        state.richString.text shouldBe expectedText
+
+        // The "b" was replaced by "x" (which is an overlap edit), so the new text inherits the span.
+        val spans = state.richString.spans
+        spans.size shouldBe 1
+        spans.first().range shouldBe (1..1)
+        spans.first().attributes shouldBe attributeContainerOf(BoldKey to Unit)
+    }
 }
 
 private fun RichTextState.simulateTypingAtEnd(text: String) {

--- a/richtext-editor/src/commonTest/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
+++ b/richtext-editor/src/commonTest/kotlin/dev/mkeeda/arranger/richtext/editor/RichTextStateTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.text.TextRange
 import dev.mkeeda.arranger.richtext.BlockquoteKey
 import dev.mkeeda.arranger.richtext.BoldKey
 import dev.mkeeda.arranger.richtext.BulletListKey
+import dev.mkeeda.arranger.richtext.HeadingKey
+import dev.mkeeda.arranger.richtext.HeadingLevel
 import dev.mkeeda.arranger.richtext.ItalicKey
 import dev.mkeeda.arranger.richtext.ListIndentLevel
 import dev.mkeeda.arranger.richtext.RgbaColor
@@ -721,8 +723,8 @@ class RichTextStateTest {
                 initialText =
                     RichString(text = initialText).edit {
                         setParagraphAttribute(
-                            dev.mkeeda.arranger.richtext.HeadingKey,
-                            dev.mkeeda.arranger.richtext.HeadingLevel.H1,
+                            HeadingKey,
+                            HeadingLevel.H1,
                             range = initialText.indices,
                         )
                     },
@@ -757,8 +759,8 @@ class RichTextStateTest {
                 initialText =
                     RichString(text = initialText).edit {
                         setParagraphAttribute(
-                            dev.mkeeda.arranger.richtext.HeadingKey,
-                            dev.mkeeda.arranger.richtext.HeadingLevel.H1,
+                            HeadingKey,
+                            HeadingLevel.H1,
                             range = initialText.indices,
                         )
                     },
@@ -785,7 +787,7 @@ class RichTextStateTest {
         spans.first().range shouldBe (0..21)
         spans.first().attributes shouldBe
             attributeContainerOf(
-                dev.mkeeda.arranger.richtext.HeadingKey to dev.mkeeda.arranger.richtext.HeadingLevel.H1,
+                HeadingKey to HeadingLevel.H1,
             )
     }
 


### PR DESCRIPTION
Resolves #75

## Overview
This PR fixes issues where inline span attributes and paragraph attributes inadvertently leak or expand when typing with the iOS software keyboard (or any IME that relies heavily on whole-word replacements). 

## Implementation Details
- **`RichTextState.kt`**: Updated the `updateRichString` method to calculate the minimal diff (delta) from `TextFieldBuffer.changes`. By trimming common prefixes and suffixes between the original text and the new text, full-word replacements are narrowed down to precise character additions or deletions.
- This prevents spans from erroneously expanding over newly inserted text (Issue 1) and correctly triggers the `EnterKeyStrategy` when newlines are inserted via IME replacements, preventing paragraph styles from bleeding into new lines (Issue 2).
- **`RichTextStateTest.kt`**: Added comprehensive test cases to verify span behavior during text replacements and pasting.