### PR TITLE
perf(build): optimize CI test performance by enabling parallel execution and build caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Run Verification (Check, Screenshot Verify)
-        run: ./gradlew check verifyRoborazzi
+        env:
+          ORG_GRADLE_PROJECT_org.gradle.workers.max: 4
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx8192m -Dfile.encoding=UTF-8 -XX:+UseParallelGC'"
+        run: ./gradlew check verifyRoborazzi -Pkotlin.daemon.jvmargs="-Xmx4096m"
 
       - name: Upload JVM Verification Reports
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
 
       - name: Run iOS Simulator Tests
-        run: ./gradlew iosSimulatorArm64Test -Pkotlin.native.tests.device="iPhone 15"
+        env:
+          ORG_GRADLE_PROJECT_kotlin.native.binary.threadCount: 3
+          ORG_GRADLE_PROJECT_org.gradle.workers.max: 3
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx5120m -Dfile.encoding=UTF-8 -XX:+UseParallelGC'"
+        run: ./gradlew iosSimulatorArm64Test -Pkotlin.native.tests.device="iPhone 15" -Pkotlin.daemon.jvmargs="-Xmx3072m"
 
       - name: Upload iOS Verification Reports
         uses: actions/upload-artifact@v7

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+# Enable parallel execution, build cache, and configuration cache for performance
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 


### PR DESCRIPTION
## Overview
Optimizes CI test execution time and local build speed by enabling Gradle parallel execution, build cache, and configuration cache.

## Implementation Details
- Enabled `org.gradle.parallel=true` in `gradle.properties` for multi-module parallel execution.
- Enabled `org.gradle.caching=true` in `gradle.properties` to reuse build and test results.
- Enabled `org.gradle.configuration-cache=true` in `gradle.properties` to eliminate configuration phase overhead.
- Increased Gradle daemon JVM heap size to `-Xmx4096m -XX:+UseParallelGC`.

## Verification Results
- Executed `./gradlew check` locally (passed in 59s on 1st run, 3s on 2nd run from cache).
- Executed `./gradlew verifyRoborazzi` locally (passed in 11s).