### PR TITLE
docs(roadmap): separate roadmap into ROADMAP.md and streamline README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,29 +678,11 @@ To ensure scalability up to PC-class text sizes and pure Kotlin compatibility (K
 
 ## Development Roadmap
 
-### Phase 1: Core Foundation (Completed)
-- [x] **Core Data Structures**: Range-based attribute management using interval logic.
-- [x] **Runs API**: Semantic segmentation of text into operable chunks.
-- [x] **Compose Integration**: Native binding with `TextFieldState` and `OutputTransformation`.
-- [x] **Built-in Attributes**: Support for Bold, Italic, Underline, Color, and Headings.
+Arranger is actively evolving towards a stable **v1.0.0 (Production-Ready Release)**.
 
-### Phase 2: The Real "Editor" Engine
-- [x] **Rich Text Mutation API**: Support for `insert`, `delete`, and `replace` within `edit {}` with automatic span tracking.
-- [x] **List Support**: Implementation of `BulletList` and `OrderedList` with auto-indent and prefix management.
-- [x] **Undo/Redo Synchronization**: Full history restoration for both text and complex structural changes.
-- [x] **Material 3 UI Components**: Ready-to-use formatting toolbars, toggle buttons, and M3 Typography/Color scheme integration for building instant editor UIs.
+With **Phase 3 (KMP Architecture Migration)** successfully completed, we are currently transitioning into **v0.4.0 (Phase 4: Interoperability & Rich Features)**, focusing on Markdown/HTML import/export, WYSIWYG auto-formatting, visual block decorations, and hyperlink support.
 
-### Phase 3: Multiplatform & Interoperability (The "Killer" Features)
-- [x] **Kotlin Multiplatform (KMP)**: Core architecture migration. (See Supported Platforms for current status).
-- [ ] **Markdown & HTML Support**: Import/Export logic (CommonMark and HTML5).
-- [ ] **WYSIWYG Auto-formatting**: Real-time conversion of Markdown syntax during input (e.g., typing `**bold**` automatically formats the text).
-- [ ] **Visual Decorations**: Implementation of `TextFieldDecorator` for advanced visuals (e.g., custom drawing for blockquotes or code blocks).
-
-### Phase 4: Enterprise Scale & Advanced Layouts
-- [ ] **Inline Media**: Support for images and attachments using Compose `InlineContent`.
-- [ ] **Table Support**: Implementation of nested structural layouts for grids/tables within the editor.
-- [ ] **Declarative Constraints**: Restricting allowed formatting (e.g., "Plain text + Links only") for specific use cases.
-- [ ] **Performance Optimization**: Internal migration to Piece Table/Rope structures for document-scale text.
+For the complete version release plan, detailed milestones, and post-1.0.0 roadmap, please see [ROADMAP.md](ROADMAP.md).
 
 ## Contributing
 Contributions are welcome! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get started.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,23 +16,23 @@ The goal of `v1.0.0` is to deliver a robust, multiplatform-ready, rich text edit
 ### 🚀 v0.4.0 (Phase 4: Interoperability & Rich Features) [Next Phase]
 *Pre-releases during active development will follow `v0.4.0-alphaXX` tag conventions before final `v0.4.0` release.*
 
-* **Markdown & HTML Support:** Import / Export converters for Markdown and HTML representations.
-* **Visual Block Decorations:** Visual container rendering for blockquotes, code blocks, callouts, and background styling.
-* **WYSIWYG Auto-formatting:** Live markdown syntax replacement while typing (e.g., typing `# ` converts to H1 automatically).
-* **Hyperlink Support:** `LinkKey` attribute, URL parsing, and interactive tap/click handling across platforms.
+- [ ] **Markdown & HTML Support:** Import / Export converters for Markdown and HTML representations.
+- [ ] **Visual Block Decorations:** Visual container rendering for blockquotes, code blocks, callouts, and background styling.
+- [ ] **WYSIWYG Auto-formatting:** Live markdown syntax replacement while typing (e.g., typing `# ` converts to H1 automatically).
+- [ ] **Hyperlink Support:** `LinkKey` attribute, URL parsing, and interactive tap/click handling across platforms.
 
 ### 🔒 v1.0.0-alpha / v1.0.0-rc (Release Preparation)
-* **Public API Audit & Freeze:** Finalize and freeze public API signatures across `arranger-richtext`, `arranger-richtext-editor`, and platform-specific modules.
-* **Cross-platform Quality Verification:** Rigorous testing, memory footprint analysis, and multiplatform behavior alignment (Android, iOS, Desktop JVM, WasmJs).
+- [ ] **Public API Audit & Freeze:** Finalize and freeze public API signatures across `arranger-richtext`, `arranger-richtext-editor`, and platform-specific modules.
+- [ ] **Cross-platform Quality Verification:** Rigorous testing, memory footprint analysis, and multiplatform behavior alignment (Android, iOS, Desktop JVM, WasmJs).
 
 ---
 
 ## Post-1.0.0 Exploration (v1.x / Phase 5)
 
-* **Inline Media Support:** Support for embedded images, videos, and custom attachments within the text engine.
-* **Table / Grid Support:** Rich text table layout structures and cell-based editing models.
-* **Declarative Constraints:** Schema-based validation rules to restrict or sanitize available attributes in specific text fields.
-* **Performance Optimization:** Internal refactoring to data structures like Piece Table or Rope for ultra-large text files.
+- [ ] **Inline Media Support:** Support for embedded images, videos, and custom attachments within the text engine.
+- [ ] **Table / Grid Support:** Rich text table layout structures and cell-based editing models.
+- [ ] **Declarative Constraints:** Schema-based validation rules to restrict or sanitize available attributes in specific text fields.
+- [ ] **Performance Optimization:** Internal refactoring to data structures like Piece Table or Rope for ultra-large text files.
 
 ---
 
@@ -41,26 +41,26 @@ The goal of `v1.0.0` is to deliver a robust, multiplatform-ready, rich text edit
 <details>
 <summary><b>v0.1.0 - Phase 1: Core Foundation</b></summary>
 
-* Initial Type-Safe Attribute System (`SpanAttributeKey`, `ParagraphAttributeKey`, `AttributeContainer`).
-* Range tracking and automatic span index shifting during basic mutations.
-* Primitive Compose UI integration with `AnnotatedString` conversion.
+- [x] Initial Type-Safe Attribute System (`SpanAttributeKey`, `ParagraphAttributeKey`, `AttributeContainer`).
+- [x] Range tracking and automatic span index shifting during basic mutations.
+- [x] Primitive Compose UI integration with `AnnotatedString` conversion.
 </details>
 
 <details>
 <summary><b>v0.2.0 - Phase 2: The Real "Editor" Engine</b></summary>
 
-* Advanced dynamic editing with `RichTextBuffer` and `RichTextState`.
-* Built-in paragraph formatting (Headings, Blockquotes, Alignments, Bullet & Ordered Lists).
-* Custom `ListMarkerResolver` and dynamic enter key strategies (`InheritParagraphStrategy`, `ListEnterStrategy`, `HeadingEnterStrategy`).
-* Full Undo / Redo engine tracking text mutations and span modifications.
-* Semantic "Runs" iteration and batch attribute editing (`editAll`, `runs`).
+- [x] Advanced dynamic editing with `RichTextBuffer` and `RichTextState`.
+- [x] Built-in paragraph formatting (Headings, Blockquotes, Alignments, Bullet & Ordered Lists).
+- [x] Custom `ListMarkerResolver` and dynamic enter key strategies (`InheritParagraphStrategy`, `ListEnterStrategy`, `HeadingEnterStrategy`).
+- [x] Full Undo / Redo engine tracking text mutations and span modifications.
+- [x] Semantic "Runs" iteration and batch attribute editing (`editAll`, `runs`).
 </details>
 
 <details>
 <summary><b>v0.3.0 - Phase 3: Kotlin Multiplatform (KMP) Architecture Migration</b></summary>
 
-* Full KMP refactoring supporting Android, Desktop (JVM), iOS, and Web (WasmJs).
-* Separation of pure Kotlin core (`arranger-richtext`) and Compose UI binding layer (`arranger-richtext-editor`).
-* Material 3 integration module (`arranger-richtext-editor-material3`).
-* Sample app for all multiplatform targets.
+- [x] Full KMP refactoring supporting Android, Desktop (JVM), iOS, and Web (WasmJs).
+- [x] Separation of pure Kotlin core (`arranger-richtext`) and Compose UI binding layer (`arranger-richtext-editor`).
+- [x] Material 3 integration module (`arranger-richtext-editor-material3`).
+- [x] Sample app for all multiplatform targets.
 </details>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,66 @@
+# Arranger Development Roadmap
+
+Arranger is actively evolving towards a stable **v1.0.0 (Production-Ready Release)**.
+This document outlines our release plan, current focus, future aspirations, and historical milestones.
+
+---
+
+## Target: v1.0.0 (Production-Ready Release)
+
+The goal of `v1.0.0` is to deliver a robust, multiplatform-ready, rich text editing engine with stable public APIs, comprehensive format support (Markdown / HTML), visual block decorations, and high reliability across all supported platforms (Android, iOS, Desktop, Wasm).
+
+---
+
+## Version Release Plan (Targeting v1.0.0)
+
+### 🚀 v0.4.0 (Phase 4: Interoperability & Rich Features) [Next Phase]
+*Pre-releases during active development will follow `v0.4.0-alphaXX` tag conventions before final `v0.4.0` release.*
+
+* **Markdown & HTML Support:** Import / Export converters for Markdown and HTML representations.
+* **Visual Block Decorations:** Visual container rendering for blockquotes, code blocks, callouts, and background styling.
+* **WYSIWYG Auto-formatting:** Live markdown syntax replacement while typing (e.g., typing `# ` converts to H1 automatically).
+* **Hyperlink Support:** `LinkKey` attribute, URL parsing, and interactive tap/click handling across platforms.
+
+### 🔒 v1.0.0-alpha / v1.0.0-rc (Release Preparation)
+* **Public API Audit & Freeze:** Finalize and freeze public API signatures across `arranger-richtext`, `arranger-richtext-editor`, and platform-specific modules.
+* **Cross-platform Quality Verification:** Rigorous testing, memory footprint analysis, and multiplatform behavior alignment (Android, iOS, Desktop JVM, WasmJs).
+
+---
+
+## Post-1.0.0 Exploration (v1.x / Phase 5)
+
+* **Inline Media Support:** Support for embedded images, videos, and custom attachments within the text engine.
+* **Table / Grid Support:** Rich text table layout structures and cell-based editing models.
+* **Declarative Constraints:** Schema-based validation rules to restrict or sanitize available attributes in specific text fields.
+* **Performance Optimization:** Internal refactoring to data structures like Piece Table or Rope for ultra-large text files.
+
+---
+
+## Completed Milestones
+
+<details>
+<summary><b>v0.1.0 - Phase 1: Core Foundation</b></summary>
+
+* Initial Type-Safe Attribute System (`SpanAttributeKey`, `ParagraphAttributeKey`, `AttributeContainer`).
+* Range tracking and automatic span index shifting during basic mutations.
+* Primitive Compose UI integration with `AnnotatedString` conversion.
+</details>
+
+<details>
+<summary><b>v0.2.0 - Phase 2: The Real "Editor" Engine</b></summary>
+
+* Advanced dynamic editing with `RichTextBuffer` and `RichTextState`.
+* Built-in paragraph formatting (Headings, Blockquotes, Alignments, Bullet & Ordered Lists).
+* Custom `ListMarkerResolver` and dynamic enter key strategies (`InheritParagraphStrategy`, `ListEnterStrategy`, `HeadingEnterStrategy`).
+* Full Undo / Redo engine tracking text mutations and span modifications.
+* Semantic "Runs" iteration and batch attribute editing (`editAll`, `runs`).
+</details>
+
+<details>
+<summary><b>v0.3.0 - Phase 3: Kotlin Multiplatform (KMP) Architecture Migration</b></summary>
+
+* Full KMP refactoring supporting Android, Desktop (JVM), iOS, and Web (WasmJs).
+* Separation of pure Kotlin core (`arranger-richtext`) and Compose UI binding layer (`arranger-richtext-editor`).
+* Material 3 integration module (`arranger-richtext-editor-material3`).
+* Sample app for all multiplatform targets.
+</details>


### PR DESCRIPTION
## Overview
This PR separates the detailed development roadmap from `README.md` into a dedicated `ROADMAP.md` file. It re-organizes the project release milestones leading up to `v1.0.0` and formats pending and completed tasks as GitHub Markdown task lists (`- [ ]` / `- [x]`).

## Implementation Details
- Created `ROADMAP.md` at the project root with the updated version release plan:
  - **v0.4.0 (Phase 4: Interoperability & Rich Features)**: Markdown & HTML Support, Visual Block Decorations, WYSIWYG Auto-formatting, Hyperlink Support.
  - **v1.0.0-alpha / v1.0.0-rc**: Public API Audit & Freeze, Cross-platform Quality Verification.
  - **v1.0.0**: Production-Ready Release.
  - **Post-1.0.0 Exploration (v1.x / Phase 5)**: Inline Media, Table / Grid Support, Declarative Constraints, Performance Optimization.
  - **Completed Milestones**: Archived `v0.1.0` (Phase 1), `v0.2.0` (Phase 2), and `v0.3.0` (Phase 3: KMP Migration) inside `<details>` collapsible sections.
- Streamlined the "Development Roadmap" section in `README.md` to a concise summary pointing to `ROADMAP.md`.
- Formatted all roadmap items using GitHub Markdown checkboxes for interactive task tracking.

## Verification Results
- Checked formatting and style with `./gradlew spotlessCheck` (Passed).
- Ran unit tests with `./gradlew test` (Passed).
- Verified markdown links and document hierarchy across `README.md` and `ROADMAP.md`.